### PR TITLE
Add placeholder heading in placeHolder.md

### DIFF
--- a/placeHolder.md
+++ b/placeHolder.md
@@ -1,1 +1,1 @@
-
+# Place holder #


### PR DESCRIPTION
Replace the stray hyphen with a Markdown level-1 heading '# Place holder #' in placeHolder.md so the file serves as a proper placeholder. (File ends without a trailing newline.)