### PR TITLE
Refactor job documentation and remove redundant order option

### DIFF
--- a/JOBS_UPDATED.md
+++ b/JOBS_UPDATED.md
@@ -6,11 +6,34 @@ This file tracks all job documentation updates and changes.
 
 | Job Name | Date Updated |
 |----------|--------------|
+| executeWorkflow.md | 2026-03-24 |
+| routeFromMetaData.md | 2026-03-24 |
+| clearWorkflowContext.md | 2026-03-24 |
+| synchronizedCounter.md | 2026-03-24 |
+| resetSynchronizedCounter.md | 2026-03-24 |
+| forEachResourceStart.md | 2026-03-24 |
+| forEachResourceStop.md | 2026-03-24 |
+| parseJsonToResource.md | 2026-03-24 |
+| parseCsvToResource.md | 2026-03-24 |
+| unitOperations.md | 2026-03-24 |
+| groupOperations.md | 2026-03-24 |
+| findOrCreateUnits.md | 2026-03-24 |
+| saveToGroup.md | 2026-03-24 |
+| findMessageTemplateAsResource.md | 2026-03-24 |
+| answerSender.md | 2026-03-24 |
+| notifyUi.md | 2026-03-24 |
+| sendMessageToGroups.md | 2026-03-24 |
+| placeHolder.md | 2026-03-24 |
+| setDebugMode.md | 2026-03-24 |
+| addWorkflowStartsTag.md | 2026-03-24 |
 | dataOperations.md | 2026-03-23 |
 | jsonPipeline.md | 2026-03-23 |
 | unitPipeline.md | 2026-03-23 |
 | sendApiResponse.md | 2026-03-17 |
 | sendHttpRequest.md | 2026-03-17 |
+
+## Planned Updates
+
 
 ## Format Template
 

--- a/JOBS_UPDATED.md
+++ b/JOBS_UPDATED.md
@@ -1,0 +1,51 @@
+# Documentation Updates Tracker
+
+This file tracks all job documentation updates and changes.
+
+## Update History
+
+| Job Name | Date Updated |
+|----------|--------------|
+| dataOperations.md | 2026-03-23 |
+| jsonPipeline.md | 2026-03-23 |
+| unitPipeline.md | 2026-03-23 |
+| sendApiResponse.md | 2026-03-17 |
+| sendHttpRequest.md | 2026-03-17 |
+
+## Format Template
+
+When updating a job file, use this standard format:
+
+### [Job Name]
+
+[Brief description]
+
+#### Properties
+
+* **Property Name** (optional/required)
+  * Description (e.g. `{{metadata.key}}`).
+
+#### Referencing Syntax
+
+Explain how to reference values in this job.
+
+#### [Step/Operation Name]
+
+Description of what this step does.
+
+* **Property** (optional/required)
+  * Description with example.
+
+#### Best Practices
+
+Tips and guidelines for using this job effectively.
+
+#### Related Jobs
+
+List related jobs that work together.
+
+#### References
+
+* [Link Title](URL)
+  * Description of what this reference covers.
+

--- a/addWorkflowStartsTag.md
+++ b/addWorkflowStartsTag.md
@@ -1,0 +1,43 @@
+# Add Workflow Starts Tag
+
+The Add Workflow Starts Tag job sets a searchable tag on the current workflow-start instance. Use it to attach dynamic values to a workflow execution so that the workflow start can be found or filtered later using meaningful runtime tags.
+
+## Properties
+
+The properties for configuring the job are described below.
+
+* **Tag source** (required)
+  * Source expression or statement that resolves to the tag value to add at runtime.
+
+## Referencing syntax
+
+Use standard statement syntax when building the tag value.
+
+* Read metadata with `{{metadata.key}}`.
+* Read resource values with expressions such as `{{resourceName.key}}`.
+* Build descriptive tags from dynamic values, for example `order:{{metadata.order_id}}`.
+
+## Execution behavior
+
+This job updates the current workflow-start record rather than a unit, group, or ordinary workflow context metadata key.
+
+* The resolved tag value is added to the current workflow-start instance.
+* The tag can then be used to search for or filter workflow-start records later.
+* The workflow continues immediately after the tag is added.
+
+## Best practices and tips
+
+* Keep tags short, descriptive, and consistent so they remain useful for searching.
+* Prefer stable business identifiers such as order IDs, customer IDs, or correlation IDs over free-form text.
+* Use prefixes such as `order:` or `integration:` when you want tags from different use cases to stay easy to distinguish.
+
+## Related jobs
+
+* [executeWorkflow.md](executeWorkflow.md)
+* [notifyUi.md](notifyUi.md)
+* [workflow.md](workflow.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+  * Reference for building dynamic tag values from metadata and resource expressions.

--- a/answerSender.md
+++ b/answerSender.md
@@ -1,18 +1,48 @@
-# Answer sender #
+# Answer Sender
 
-*This job is used to answer the sender of the incoming message or “sender” of the form answer*
+The Answer Sender job replies to the originator of an incoming message or form answer. Use it when a workflow should answer the person who started the conversation without having to build the recipient selection manually.
 
+## Properties
 
-The goal of the job is to create an answer/reply to the sender of the incoming message or to the “sender” of the form answer.  
-Prioritizes like this: If there is an IncomingMessage then this will be the sender to answer. If there is no IncomingMessage, but there is a FormAnswer, then answer the “sender” of that FormAnswer.  
-Incoming message will be set if the execution was started with an IncomingMessageTrigger, and FormAnswer will be available if the FormAnsweredTrigger has started the execution.
+The properties for configuring the reply are described below.
 
+* **Message** (optional)
+	* Connected message template used for the reply.
+* **Message resource** (optional)
+	* Message resource to use instead of a directly connected message template.
+* **Override answer sender source** (optional; default: incomingunit)
+	* Source used to override which unit receives the reply.
 
+## Referencing syntax
 
-**Notes:  
-Will abort if required IncomingMessage or FormAnswer is not set.
-Will abort if the “sender”-unit doesn’t exist.
-Will use defaulting behavior for message..**
+You can override the reply target using a workflow expression.
 
-**How to:**
-Connect to the message template (message to reply with).
+* Use `incomingunit` to rely on the default reply target.
+* Use another resource or expression in **Override answer sender source** when the reply should go to a different unit selected earlier in the workflow.
+
+## Sender selection
+
+The job resolves the reply target in a defined order.
+
+* First, it tries the sender from `IncomingMessage`.
+* If no incoming message is available, it falls back to the sender of `FormAnswer`.
+* If neither source exists, the job aborts.
+
+The job also aborts if the sender unit cannot be resolved.
+
+## Best practices and tips
+
+* Use a connected message template when the reply content is static or centrally managed.
+* Use **Message resource** when the workflow selects or builds the message dynamically.
+* Override the sender source only when the workflow intentionally answers a different resolved unit than the default sender.
+
+## Related jobs
+
+* [answerFormQuestion.md](answerFormQuestion.md)
+* [sendMessageToGroups.md](sendMessageToGroups.md)
+* [messageTemplate.md](messageTemplate.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Helpful when the reply target or message resource comes from workflow expressions.

--- a/clearWorkflowContext.md
+++ b/clearWorkflowContext.md
@@ -1,20 +1,60 @@
-# Clear workflow context #
+# Clear Workflow Context
 
-*This job is used to clear parts of the WFC.*
+The Clear Workflow Context job removes selected data from the current workflow context. Use it to reset temporary state between workflow steps, clean up after a branch, or make sure downstream jobs do not accidentally reuse earlier metadata or resources.
 
-Clearing temporary group will remove all members that are read into the WFC as group members.  
-Clearing Groups will remove all groups from Workflow groups, this means that ExtractData would not find any GroupIds to read group members into the WFC. It also means that there are no Groups that SendMessageToGroups will default back to.  
-Clearing IncomingUnit will remove the WFC resource IncomingUnit, and jobs that require the IncomingUnit will fail, unless it is set/made available again.  
-Clearing IncomingGroupMember removes the IncomingGroupMember from WFC, with the similar consequences as removing IncomingUnit.  
-ClearMetaData is a RegEx expression that will test each key in the WFC metadata and remove if it matches. This means setting ClearMetaData to: .* will cause all metadata to be removed.
+## Properties
 
+The properties for configuring the cleanup are described below.
 
+* **Clear temporary group** (optional; default: false)
+	* Removes all members from the workflow context temporary group.
+* **Clear groups** (optional; default: false)
+	* Removes workflow groups from the workflow context.
+* **Clear incoming unit** (optional; default: false)
+	* Removes the `IncomingUnit` resource from the workflow context.
+* **Clear files** (optional; default: false)
+	* Removes files stored in the workflow context.
+* **Clear incoming group member** (optional; default: false)
+	* Removes the `IncomingGroupMember` resource from the workflow context.
+* **Clear meta data** (optional)
+	* Regular expression used to match metadata keys that should be removed.
+* **Clear resources** (optional)
+	* Regular expression used to match resource names that should be removed.
 
-**Notes:  
-If ClearMetaData is left empty, then the job will NOT clear any metadata.  
-ClearMetaData is a RegEx-expression.**
+## Referencing syntax
 
-**How to:**  
-Set what properties to clear.   
-Remember that ClearMetaData is RegEx-expression and written in text, the others are true/false selected from the list.
+The two pattern-based properties use regular expressions.
+
+* Leave **Clear meta data** empty to keep all metadata.
+* Use `.*` in **Clear meta data** to remove all metadata keys.
+* Leave **Clear resources** empty to keep all resources.
+* Use targeted patterns such as `^tmp_` when you want to clear only temporary keys or resources with a naming convention.
+* Use the format `^name$` when you want to match one exact metadata key or one exact resource name only. For example, `^customer_id$` matches only that metadata key, and `^request$` matches only a resource named `request`.
+
+## Cleanup behavior
+
+Each option affects a different part of the workflow context.
+
+* Clearing groups removes fallback groups that some downstream jobs rely on.
+* Clearing the incoming unit or incoming group member can cause later jobs to fail if they require those resources.
+* Regex-based clearing is applied by name, so the pattern should be reviewed carefully before using broad matches.
+
+## Best practices and tips
+
+* Clear only the parts of the workflow context you no longer need.
+* Prefer targeted regex patterns over `.*` unless a full reset is intentional.
+* When a workflow later depends on `IncomingUnit`, groups, or files, clear those values only after the dependent jobs have finished.
+
+## Related jobs
+
+* [filterWorkflowContext.md](filterWorkflowContext.md)
+* [splitWorkflowContext.md](splitWorkflowContext.md)
+* [workflowContext.md](workflowContext.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Background on metadata and resource naming within the workflow context.
+* [Working With Strings](https://help.bosbec.com/knowledge-base/working-with-strings/)
+	* Useful when writing regex patterns for metadata or resource cleanup.
 

--- a/dataOperations.md
+++ b/dataOperations.md
@@ -41,8 +41,6 @@ Encodes or decodes a value using Base64.
   * Override the default encoding.
 * **Data type** (optional)
   * Options: **Text**, **Hex**
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Calculate data
 
@@ -54,8 +52,6 @@ Evaluates an arithmetic expression using workflow context values.
   * Where to store the result.
 * **Amount of decimals in result** (optional)
   * Number of decimal places in the result; defaults to 2.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Calculate date time diff
 
@@ -71,8 +67,6 @@ Calculates the difference between two timestamps.
   * Output format. Options: `totaldays`, `totalhours`, `totalminutes`, `totalseconds`, `totalmilliseconds`
 * **Default for missing values** (optional)
   * Whether to use a default value when one of the timestamps is missing.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Calculate GPS distance
 
@@ -88,8 +82,6 @@ Calculates the distance in kilometers between two GPS coordinates.
   * The second latitude value (e.g. `{{metadata.latitude_2}}`).
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Concat
 
@@ -101,8 +93,6 @@ This step is generally no longer needed with the new syntax, since strings can b
   * Template string using `{metadata.key}` placeholders (e.g. `{metadata.firstname} {metadata.lastname}`).
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Concat group member data
 
@@ -120,8 +110,6 @@ Concatenates a formatted string for each member of a group, separated by a separ
   * Use all groups in the workflow context.
 * **Override replacements** (optional)
   * Character substitutions applied to group member data before concatenation.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Concat unit resource data
 
@@ -139,8 +127,6 @@ Concatenates a formatted string from items in a workflow context unit resource.
   * Text or character placed between each row.
 * **Override replacements** (optional)
   * Character substitutions applied before concatenation.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Count group members
 
@@ -150,8 +136,6 @@ Counts the number of members in a group and stores the result.
   * The group ID or source of the group identifier.
 * **Destination** (optional)
   * Where to store the count.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Create short link
 
@@ -161,8 +145,6 @@ Creates a shortened URL from a source value.
   * Source containing the full URL to shorten (e.g. `{{metadata.url}}`).
 * **Destination** (optional)
   * Where to store the short link.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Encode decode
 
@@ -178,8 +160,6 @@ Encodes or decodes a value using a specified encoding type.
   * Encoding format to use (e.g. `utf-8`, `ascii`).
 * **Non default encoding name** (optional)
   * Override the encoding name.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Extract value regex
 
@@ -195,8 +175,6 @@ Extracts text from a source using a regex pattern.
   * Options: **First match**, **Last match**, **Every match**
 * **Result destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Filter CSV string
 
@@ -208,8 +186,6 @@ Filters a comma-separated string against a comparison value.
   * Source of the comparison value (e.g. `{{metadata.filter_value}}`).
 * **Result destination** (optional)
   * Where to store the filtered result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get calculated log data
 
@@ -225,8 +201,6 @@ Aggregates data log values using sum, max, min, or average.
   * End of the time range (e.g. `{{metadata.end_date}}`).
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get country info
 
@@ -236,8 +210,6 @@ Looks up country metadata from a name or ISO code.
   * Country name or ISO code to look up (e.g. `{{metadata.country}}`).
 * **Destination prefix** (optional)
   * Prefix for result keys (e.g. `country` produces `metadata.country_iso`, `metadata.country_name`, etc.).
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get data log keys
 
@@ -251,8 +223,6 @@ Retrieves a list of data log keys and stores them in a resource.
   * Number of keys per page.
 * **Only for administrators** (optional)
   * Filter to administrator-scoped keys only.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get date from week number
 
@@ -266,8 +236,6 @@ Converts a week number and year to a date.
   * Options: **Sunday**, **Monday**, **Tuesday**, **Wednesday**, **Thursday**, **Friday**, **Saturday**
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get day of week
 
@@ -277,8 +245,6 @@ Returns the day of week for a given date.
   * Source of the date; defaults to the execution date if empty (e.g. `{{metadata.date}}`).
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get last log data
 
@@ -288,8 +254,6 @@ Retrieves the most recent value stored for a data log key.
   * The log key to read from.
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get relative date
 
@@ -309,8 +273,6 @@ Calculates a relative calendar date (e.g. the first Monday of March).
   * Where to store the result.
 * **Destination format** (optional; default: `yyyy-MM-dd HH:mm:ssZ`)
   * Format for the output date.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Get week number
 
@@ -320,8 +282,6 @@ Returns the ISO week number for a given date.
   * Source of the date (e.g. `{{metadata.date}}`).
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Hash
 
@@ -347,8 +307,6 @@ Hashes a value using a standard or HMAC algorithm.
     * **Bosbec hash type** (optional) — Options: **Parse from string**, **MD5**, **SHA1**, **SHA256**, **SHA384**, **SHA512**
     * **Non default encoding name** (optional) — override the default encoding (ASCII).
     * **Non default output format** (optional; default: `X2`) — use `x2` for lowercase hex output.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Insert regex
 
@@ -366,8 +324,6 @@ Inserts a value into text at a position matched by a regex pattern.
   * Returns the original source if no match is found.
 * **Options** (optional)
   * Options: **Before**, **After**, **First match**, **Last match**, **Every match**
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Log data
 
@@ -385,8 +341,6 @@ Writes a value to a data log.
   * Where to store the ID of the data log entry written.
 * **Item metadata** (optional)
   * Additional key-value metadata to attach to the log entry.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Modify date
 
@@ -412,8 +366,6 @@ Adds or subtracts time units from a timestamp.
   * The expected input format (e.g. `yyyy-MM-ddTHH:mm:ssZ`). Common formats are tried automatically if omitted.
 * **Destination format** (optional)
   * The desired output format (e.g. `yyyy-MM-ddTHH:mm:ssZ`).
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Pad
 
@@ -429,8 +381,6 @@ Pads a string to a specified total width with a given character.
   * Total character width of the padded string.
 * **Pad char** (optional)
   * The character to pad with.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Parse epoch time
 
@@ -442,8 +392,6 @@ Converts a Unix timestamp (seconds or milliseconds) to a date-time string.
   * Toggle if the input is in milliseconds rather than seconds.
 * **Destination** (optional)
   * Where to store the parsed date-time.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Parse phone
 
@@ -457,8 +405,6 @@ Validates and parses a phone number into its components.
   * Where to store the boolean validation result (`true`/`false`).
 * **Phone number destination** (optional)
   * Where to store the normalised phone number.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Remove regex
 
@@ -476,8 +422,6 @@ Removes text matched by a regex pattern.
   * Options: **First match**, **Last match**, **Every match**
 * **Result destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Remove resource
 
@@ -485,8 +429,6 @@ Removes a named resource from the workflow context.
 
 * **Resource name** (optional)
   * Name of the resource to remove.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Replace
 
@@ -500,8 +442,6 @@ Replaces a literal string within a value.
   * The value to replace the found string with.
 * **Destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Replace regex
 
@@ -519,8 +459,6 @@ Replaces text matched by a regex pattern.
   * Returns the original source if no match is found.
 * **Result destination** (optional)
   * Where to store the result.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Set data
 
@@ -530,8 +468,6 @@ Copies a value from a source to a destination in the workflow context.
   * Value or source of value (e.g. `{{metadata.phonenumber}}` or a literal value such as `+46700000001`).
 * **Destination** (optional)
   * Where to store the value (e.g. `metadata.phonenumber` or `incomingUnit.metadata.phonenumber`).
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Split string
 
@@ -545,8 +481,6 @@ Splits a string on a delimiter and stores the parts as indexed metadata keys or 
   * The delimiter to split on.
 * **Result as resource** (optional)
   * Name of a resource to store all parts in. Cannot be combined with **Destination key**.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Substring
 
@@ -566,8 +500,6 @@ Extracts a portion of a string by start index and maximum length.
   * The maximum number of characters to extract (static value).
 * **Substring by text element** (optional)
   * When enabled, emoji and other multi-char sequences count as a single character.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### Time based OTP code
 
@@ -579,8 +511,6 @@ Generates a time-based one-time password (TOTP).
   * The user identifier associated with the TOTP (e.g. `{{metadata.username}}`).
 * **Destination** (optional)
   * Where to store the generated code.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ### UTF
 
@@ -596,8 +526,6 @@ Converts UTF-encoded text from hex notation to readable characters.
     * **Override default notation** (optional) — override the default `\u` prefix.
   * **From UTF-8 hex** — converts from UTF-8 hex notation (e.g. `\x41`)
     * **Override default notation** (optional) — override the default `\x` prefix.
-* **Order** (optional)
-  * Execution order within the operations list.
 
 ## Execution paths
 

--- a/executeWorkflow.md
+++ b/executeWorkflow.md
@@ -1,15 +1,60 @@
+# Execute Workflow
 
-# Execute workflow #
+The Execute Workflow job starts another workflow by searching for it by name or ID. Use it when you want to split logic into reusable workflows, trigger a public workflow from another account, or launch a subprocess with selected metadata and triggers.
 
-*Will try to find a workflow and run it.*
+## Properties
 
-Provide a workflow- name or id to execute that workflow.  
-Can be used with public workflows spanning all accounts or a local workflow from your account.
+The properties for configuring the job are described below.
 
+* **Workflow search phrase** (required)
+	* Workflow name or workflow ID to search for and execute.
+* **Trigger names** (optional)
+	* Comma-separated list of trigger names to activate in the target workflow.
+* **Initiation tags** (optional)
+	* Tags that identify or categorize the workflow start in the target workflow.
+* **Execute with metadata** (optional)
+	* Key-value metadata passed to the target workflow at start.
+* **Search public** (optional; default: false)
+	* If enabled, the search includes public workflows outside the current account.
+* **Ignore current workflow metadata** (optional; default: false)
+	* If enabled, the current workflow context metadata is not forwarded automatically.
+* **Allow recursive executions** (optional; default: false)
+	* If enabled, the workflow is allowed to execute itself.
+* **Exclude resources regex** (optional)
+	* Regular expression used to prevent matching resources from being forwarded to the target workflow.
 
-**Notes:  
-Remember to check the box if trying to execute the same workflow as this job is in.**
+## Referencing syntax
 
-**How to:**  
-Set workflow name or id.  
-Make sure the workflow is available for your workflow to call it.
+Use standard workflow expressions when building metadata or search values for the target workflow.
+
+* Read workflow context metadata with `{{metadata.key}}`.
+* Pass metadata keys in **Execute with metadata** using destination keys and dynamic values, for example `customer_id` = `{{metadata.customer_id}}`.
+* Use **Exclude resources regex** to omit resources whose names match a pattern when forwarding workflow context resources.
+
+## Execution behavior
+
+The job searches for the target workflow, starts it, and then continues based on the workflow design.
+
+* Use **Workflow search phrase** to target a specific workflow by name or ID.
+* Use **Trigger names** when the target workflow exposes more than one trigger and you want explicit control over which entry points are activated.
+* By default, the current workflow context metadata is forwarded. Enable **Ignore current workflow metadata** when the called workflow should receive only the metadata you define explicitly.
+* Enable **Allow recursive executions** only when self-execution is intentional and bounded.
+
+## Best practices and tips
+
+* Prefer workflow IDs when the target workflow name may change over time.
+* Pass only the metadata the called workflow actually needs so the interface between workflows stays clear.
+* Use **Ignore current workflow metadata** together with **Execute with metadata** when you want the called workflow to behave like a clean subprocess.
+* Be careful with **Allow recursive executions**. Add a clear stop condition elsewhere in the workflow design to avoid runaway loops.
+
+## Related jobs
+
+* [routeFromMetaData.md](routeFromMetaData.md)
+* [executeOrPostpone.md](executeOrPostpone.md)
+* [workflow.md](workflow.md)
+* [addWorkflowStartsTag.md](addWorkflowStartsTag.md)
+
+## References
+
+* [Getting started: Integrations](https://help.bosbec.com/knowledge-base/getting-started-integrations/)
+	* Conceptual guidance for structuring workflows that coordinate data movement between systems.

--- a/findMessageTemplateAsResource.md
+++ b/findMessageTemplateAsResource.md
@@ -1,16 +1,52 @@
-# Find Message Template As Resource #
+# Find Message Template As Resource
 
-*This job finds message templates and store as resource in the workflow context.*
+The Find Message Template As Resource job finds message templates by name, ID, or metadata filter and stores the result as a workflow resource. Use it when later jobs should work with a message template loaded dynamically at runtime.
 
-The search phrase will search for a message template by id or name.  
-Resource name is the result, where the found message template(s) will be stored.  
+## Properties
 
-Use Met data filter to get message templates based on the metadata.  
-For example getting a message template with data "metadata.message_code" : "3" can be achieved this way.
+The properties for configuring the job are described below.
 
+* **Search phrase** (optional)
+	* Name or ID of the message template to find.
+* **Resource name** (required)
+	* Name of the workflow resource that stores the result.
+* **Page index** (optional)
+	* Result page to return when many templates match.
+* **Page size** (optional)
+	* Number of templates to return per page.
+* **Meta data filter** (optional)
+	* Key-value filter used to narrow down templates by metadata.
+* **Incoming message resource name** (optional)
+	* Alias for the event resource when needed by the job configuration.
 
-**Notes:**
+## Referencing syntax
 
+Metadata filters are key-value pairs.
 
-**How to:**
-Must at least set search phrase and/or meta data filter together with resource name.
+* Use metadata keys together with the values you want to match.
+* A simple search can combine **Search phrase** with a metadata filter when both name and metadata should be considered.
+
+## Behavior
+
+The job finds matching templates and stores them in the named workflow resource.
+
+* Search by **Search phrase** when the name or ID is known.
+* Use **Meta data filter** when the workflow should select templates by attributes such as language, type, or message code.
+* Use pagination when browsing or narrowing down larger template sets.
+
+## Best practices and tips
+
+* Give the result resource a descriptive name so later message jobs are easier to read.
+* Use metadata filters when template selection should be stable even if names change.
+* Keep pagination explicit if the workflow may return more than one matching template.
+
+## Related jobs
+
+* [createMessageTemplateAsResource.md](createMessageTemplateAsResource.md)
+* [messageTemplate.md](messageTemplate.md)
+* [sendMessageToGroups.md](sendMessageToGroups.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful when filter values or resource names depend on workflow expressions.

--- a/findOrCreateUnits.md
+++ b/findOrCreateUnits.md
@@ -1,19 +1,60 @@
-# Find or Create Units #
+# Find Or Create Units
 
-*This job will first try to find units. If it cannot find units, it will create a unit matching what was searched for.*
+The Find Or Create Units job searches for units based on a workflow value and creates new units only if no matching units are found and creation is allowed. Use it when an incoming sender, email address, phone number, or similar identifier should resolve to a unit automatically.
 
-Will first try to get the value from WFC-resource in SearchSource. The value found in SearchSource will be used to try to find units.
+For many newer workflows, [unitPipeline.md](unitPipeline.md) can often be used instead of this job. Unit Pipeline gives you a more flexible step-based approach for finding, creating, filtering, updating, and saving units in one place.
 
-Depending on the property PreventCreatingUnits this job can be configured to create new unit if finding existing units isn’t successful.
+## Properties
 
-If units are found, then the FindDistinctForX. comes into play. With these properties set it is possible to make sure that only one unit with each phone number/email is returned as the find-result.
+The properties for configuring the job are described below.
 
-If SingleFoundUnitAsIncomingUnit is set to true AND the find-part of this job resulted in a single unit found, then this job will set the IncomingUnit resource.
+* **Search source** (required)
+	* Source expression or string used when searching for units, for example `incomingmessage.sender`.
+* **Single found unit as incoming unit** (optional; default: false)
+	* If enabled, a single matching unit is set as `IncomingUnit`.
+* **Prevent creating units** (optional; default: false)
+	* If enabled, the job only searches and never creates new units.
+* **Find distinct for phone number** (optional; default: false)
+	* Return at most one unit per phone number.
+* **Find distinct for email address** (optional; default: false)
+	* Return at most one unit per email address.
+* **Page index** (optional; default: 1)
+	* Result page to return when many units match.
+* **Page size** (optional; default: 50)
+	* Number of units to return per page.
 
-**Notes:**
+## Referencing syntax
 
-Can set Incoming Unit
+Use workflow expressions in **Search source** when the search input comes from the current workflow context.
 
-**How to:**
+* `{{incomingmessage.sender}}` is a common source for incoming-message workflows.
+* `{{metadata.customer_email}}` can be used when an earlier step stored the value in metadata.
 
-Set FindDistinctForX properties if you need to find only one unit.
+## Behavior
+
+The job behaves in three stages.
+
+* Search for units using **Search source**.
+* If no units are found and **Prevent creating units** is disabled, create a new unit using the searched value.
+* If exactly one unit is found and **Single found unit as incoming unit** is enabled, set that unit as `IncomingUnit`.
+
+The distinct options are useful when duplicate phone numbers or email addresses exist and the workflow should continue with only one result per channel value.
+
+## Best practices and tips
+
+* Enable creation only when the workflow is allowed to provision new units automatically.
+* Use the distinct options when duplicate channel data exists and downstream jobs expect a smaller result set.
+* Set `IncomingUnit` only when a single-unit outcome is the intended behavior for later jobs.
+* If the workflow needs more than a simple find-or-create pattern, consider using [unitPipeline.md](unitPipeline.md) instead. It is often the better fit for newer workflows that combine search, creation, filtering, updates, and saving in one sequence.
+
+## Related jobs
+
+* [unitPipeline.md](unitPipeline.md)
+* [unitOperations.md](unitOperations.md)
+* [setIncomingUnit.md](setIncomingUnit.md)
+* [getUsersFromIncomingMessage.md](getUsersFromIncomingMessage.md)
+
+## References
+
+* [Importing units](https://help.bosbec.com/knowledge-base/importing-units/)
+	* Helpful background for how unit data is commonly created and updated.

--- a/forEachResourceStart.md
+++ b/forEachResourceStart.md
@@ -1,19 +1,52 @@
-# For Each Resource Start#
+# For Each Resource Start
 
-*This job will start a "loop" in the workflow if there is a ForEachResourceStop downstreams from this start-job.*
+The For Each Resource Start job begins a loop over the items in a resource. For every iteration, it exposes the current item as a temporary resource so the jobs inside the loop can process one item at a time.
 
-Consider the case where you have a UnitResource containing 5 units and you want to update them in a series of steps. This job will let the workflow execute a sequence of jobs for each of the 5 units in the resource.  
-Each time the sequence reaches the ForEachResourceStop-job, it will start over from the location of this ForEachResourceStart-job.  
-And each time the loop-sequence starts; this ForEachResourceStart-job will take the next item (unit in this case) in the current resource (the unit resource in this case) and create a temporary resource with the name defined in CurrentItemName. This current item can be addressed by the given name as a single resource of the given type.
+## Properties
 
+The properties for configuring the loop are described below.
 
+* **Resource to iterate** (required)
+	* The resource whose items should be processed sequentially.
+* **Current item name** (required)
+	* Name of the temporary resource created for the current item during each iteration.
+* **Nested for each name** (optional)
+	* Advanced identifier used when you have nested loops and need to pair the correct start and stop jobs.
 
-**Notes:**
+## Referencing syntax
 
-Requires a ForEachResourceStop-job in order to define a loop-sequence.
+Use the name from **Current item name** to access the current item inside the loop.
 
-**How to:**
+* Read the current item with expressions such as `{{currentItemName.key}}`.
+* For a unit resource, you might reference `{{one_unit.metadata.firstname}}`.
+* For a data log item resource, you might reference `{{log_item.value}}`.
 
-Drag a ForEachResourceStart-job to the canvas.  
-Connect the sequence of jobs to iterate over and set the resource and current-item-name.  
-Finish the loop-sequence with a ForEachResourceStop-job.
+## Execution behavior
+
+This job defines two distinct paths.
+
+* **For each**
+	* Jobs on this path run once for every item in the resource.
+* **When completed**
+	* Jobs on this path run after all items have been processed.
+
+When the loop reaches [forEachResourceStop.md](forEachResourceStop.md), execution returns here and the next item is loaded into the temporary resource.
+
+## Best practices and tips
+
+* Choose a clear **Current item name** so expressions inside the loop remain readable.
+* Keep the loop body focused on work that belongs to one item at a time.
+* Use **Nested for each name** only when you need nested loops, and make sure the start and stop jobs use the same value.
+
+## Related jobs
+
+* [forEachResourceStop.md](forEachResourceStop.md)
+* [parseCsvToResource.md](parseCsvToResource.md)
+* [unitPipeline.md](unitPipeline.md)
+
+## References
+
+* [For Each Resource](https://help.bosbec.com/knowledge-base/for-each-resource/)
+	* Overview of how to configure the start and stop jobs together.
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for reading values from the current item resource inside the loop.

--- a/forEachResourceStop.md
+++ b/forEachResourceStop.md
@@ -1,3 +1,35 @@
-# For Each Resource Stop#
+# For Each Resource Stop
 
-*This job will end a "loop" in the workflow. See ForEachResourceStart for more information.*
+The For Each Resource Stop job marks the end of a loop started by For Each Resource Start. When execution reaches this job, the workflow returns to the matching start job, loads the next item from the resource, and repeats the loop until all items have been processed.
+
+## Properties
+
+The properties for configuring the loop stop are described below.
+
+* **Nested for each name** (optional)
+	* Advanced identifier used to match this stop job with the correct For Each Resource Start job when you have nested loops in the same workflow.
+
+## Execution behavior
+
+This job does not process data by itself. Instead, it controls how the loop continues.
+
+* If there are more items left in the resource, execution returns to the matching start job and runs the loop body again.
+* If there are no items left, the workflow leaves the loop and continues on the `When completed` path configured from the start job.
+* When **Nested for each name** is used, the value must match the corresponding start job so the correct loop pair is used.
+
+## Best practices and tips
+
+* Always pair this job with [forEachResourceStart.md](forEachResourceStart.md); the loop will not work correctly without a matching start job.
+* Use **Nested for each name** only when you actually need nested loops. Leave it empty for simpler workflows.
+* Keep the jobs inside the loop focused on the current item so the loop is easy to reason about and debug.
+
+## Related jobs
+
+* [forEachResourceStart.md](forEachResourceStart.md)
+* [parseCsvToResource.md](parseCsvToResource.md)
+* [unitPipeline.md](unitPipeline.md)
+
+## References
+
+* [For Each Resource](https://help.bosbec.com/knowledge-base/for-each-resource/)
+	* Explains how the start and stop jobs work together and how to reference the current item during iteration.

--- a/groupOperations.md
+++ b/groupOperations.md
@@ -1,22 +1,58 @@
-# The group operations #
+# Group Operations
 
-*This is the job that should be used when operating on a group.*
+The Group Operations job is the main pipeline job for working with groups. It lets you find groups, optionally filter them, perform group-level operations, and then decide how the resulting groups should be stored or deleted.
 
-The job has four parts, Find, Filter, Operate and Store.
+## Properties
 
+The job is organized into four pipeline stages.
 
-The idea is to get groups, optionally filter out and select a few of them, perform an operation on each of the groups after the filter. And finally perform a storage-operations such as saving to account / workflow or deleting the groups.
+* **Find steps** (required)
+	* Ordered list of steps that load or create groups.
+* **Filter steps** (optional)
+	* Ordered list of metadata-based filters applied to the found groups.
+* **Operate on group steps** (optional)
+	* Ordered list of operations such as adding members, removing members, or updating group metadata.
+* **Store step** (required)
+	* Final step that decides whether the groups are saved to the account, saved to workflow context, saved to a resource, deleted, or left unsaved.
 
+## Referencing syntax
 
-Operations can be: RemoveMembers, UpdateGroupData
+Group filters and updates typically use metadata comparisons.
 
+* Use group metadata keys when comparing group properties.
+* Use workflow metadata expressions when the comparison value should come from the current workflow context.
+* When updating group data, define the metadata keys to write and the values that should be stored.
 
+## Find, filter, operate, store
 
-**Notes:  
-See information about groups.**
+The pipeline follows a consistent sequence.
 
+* **Find**
+	* Load groups from the account, from a resource, from workflow context, or create a new group.
+* **Filter**
+	* Keep or remove groups based on metadata comparisons.
+* **Operate**
+	* Add members, remove members, or update group data.
+* **Store**
+	* Save the result to the account, to workflow groups, to a named resource, delete from the account, or do not save.
 
-**How to:**  
-Configure find-step, optionally add a filter and operation then select what store-step to take.
+## Best practices and tips
+
+* Use filters before member operations when only a subset of groups should be changed.
+* Save to a resource when later jobs need the resulting groups without immediately persisting changes to the account.
+* Keep group-metadata updates focused on a small number of keys so the pipeline remains easy to review.
+
+## Related jobs
+
+* [saveToGroup.md](saveToGroup.md)
+* [group.md](group.md)
+* [unitOperations.md](unitOperations.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful when group filters or updates depend on workflow metadata values.
+* [Comparison Operators](https://help.bosbec.com/knowledge-base/comparison-operators/)
+	* Reference for the operators used when filtering groups by metadata comparisons.
 
 

--- a/notifyUi.md
+++ b/notifyUi.md
@@ -1,30 +1,42 @@
-# Notify UI #
+# Notify UI
 
-*This job is used to send information to the user in the admin pages as bosbec.io*
+The Notify UI job sends a toast notification to the Bosbec admin user interface. Use it when a workflow should surface status information, links, or short results directly to one administrator or to all administrators on the account.
 
+## Properties
 
-This job will send a notification to the "Admin UI" found at bosbec.io.  
-Depending on what is set in the "topic" property, you can either send information to just one administrator on your account or to all administrators.  
-Note that the user must bed logged in at bosbec.io at send time, for the message to appear as a toast/notification in the upper right corner.  
+This documentation is based on the currently used configuration pattern for the job.
 
-To send a message to everyone on your account **topic** should be set to:
-```{{currentuser.accountid}}.notification```  
-And if you just want to send something to one administrator (for example the one running the workflow) set to:
-<code>{{currentuser.administratorId}}.notification</code>  
+* **Topic** (required)
+	* Destination channel that determines who should see the notification.
+* **Custom data** (required)
+	* Payload for the notification. The `message` field contains the text shown in the toast.
 
-Provide the custom data **"message"** to specify what information to display to the user.  
-For example: 
-Link: <a style= "color: #72c1ff" target="_blank" href="https://www.google.com/">https://www.google.com/</a>
-Sent at: {{datetime(HH:mm:ss)}} 
+## Referencing syntax
 
-Will provide 
-Link: https://www.google.com/ Sent at: 15:22:11
+The topic decides the audience.
 
+* Use `{{currentuser.accountid}}.notification` to notify all administrators on the account.
+* Use `{{currentuser.administratorId}}.notification` to notify one administrator.
 
-**Notes:  
-* Will not work unless you provide a correct **topic** and custom data with **message**.  
-* Optional parameter for custom data is the **persistant** which should be set to **true** if you want the toast to stay until the user click the close button.  
-* If the **persistant** is left out, the toast will automatically close after a few seconds.  
+The custom data payload should include `message`. You can also include `persistant` set to `true` if the toast should remain visible until dismissed.
 
-**How to:**
-* Set topic and custom data message
+## Notification behavior
+
+The notification appears in the admin UI as a toast.
+
+* The target user must be logged in to the Bosbec admin UI when the notification is sent.
+* The message can contain dynamic workflow values, for example timestamps or links.
+* If `persistant` is omitted, the toast closes automatically after a short time.
+
+## Best practices and tips
+
+* Keep UI notifications short and action-oriented.
+* Use account-wide topics only for information relevant to multiple administrators.
+* Prefer persistent notifications only when the message requires deliberate acknowledgement.
+
+## Related jobs
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful for building dynamic topic values and notification messages.

--- a/parseCsvToResource.md
+++ b/parseCsvToResource.md
@@ -1,22 +1,65 @@
-# Parse Csv to Resource
+# Parse CSV to Resource
 
-_This job will parse a csv-text in the "Csv source" either from a resource/metadata or just as csv-input.  
-The result is a csv resource in the workflow context._
+The Parse CSV to Resource job parses CSV-formatted text and creates a CsvResource in the workflow context. Use it when you receive rows of tabular data that need to be accessed by headers, rows, or columns in later workflow steps.
 
 ## Properties
-* **Csv source*** - (input) A value with a csv eg. _ header1, header2\n row1, row2_ or a reference to a resource for example some data in an incoming message or metadata.
-* **Destination resource name*** - (output) A name for the created csv resource.
 
-## Other
+The properties for configuring the parser are described below.
 
-The job will parse a CSV and if successful a CsvResource will be created in the workflow context.  
-To access data after this job you can (_assuming name of resulting resource is csv1_):
-* csv1.headers - returns headers/the header row
-* csv1.headers[0] - will return the header from the first position (0)
-* csv1.headers.count() - will return how many columns/headers
-* csv.rows - will return the rows
-* csv.rows[2] - will return the row from position 2
-* csv.rows[3].distinct() - should return distinct values in row with position 3
-* csv.getcolumn(xx) - where 'xx' is either the index/position for the header or a name of a given header, like 'firstname' in a csv: firstname, lastname \n .. 
-* 
-See documentation about resources and CsvResource for more in-depth understanding.
+* **CSV source** (required)
+	* Source containing the CSV text to parse, such as `{{incomingmessage.body}}` or a metadata value.
+* **Parse first row as headers** (optional; default: true)
+	* If enabled, the first row is treated as column headers.
+* **Override allow fill on mismatch** (optional; default: true)
+	* If enabled, shorter rows are padded to match the expected column count.
+* **Override new line strict** (optional; default: true)
+	* If enabled, newline matching is handled strictly when custom newline settings are used.
+* **Override new line** (optional)
+	* Custom row separator for non-standard CSV input.
+* **Override escape character for quotes** (optional)
+	* Custom escape character for quoted values.
+* **Override delimiter** (optional)
+	* Custom field delimiter such as `;`, `|`, or tab.
+* **Destination resource name** (required)
+	* Name of the CsvResource created in the workflow context.
+
+## Referencing syntax
+
+After parsing, the resulting CsvResource can be accessed through headers, rows, and helper functions.
+
+* `{{csv1.headers}}` returns all headers.
+* `{{csv1.headers[0]}}` returns the header at index `0`.
+* `{{csv1.headers.count()}}` returns the number of headers.
+* `{{csv1.rows}}` returns all rows.
+* `{{csv1.rows[2]}}` returns the row at index `2`.
+* `{{csv1.getcolumn(0)}}` returns the first column.
+* `{{csv1.getcolumn(firstname)}}` returns the column named `firstname` when headers are enabled.
+
+## Resulting resource
+
+If parsing succeeds, the job creates a CsvResource that downstream jobs can inspect or iterate over.
+
+* Headers can be read by position when the first row is treated as headers.
+* Rows can be accessed directly or processed one by one together with [forEachResourceStart.md](forEachResourceStart.md).
+* Column access is useful when later jobs need all values for one field.
+
+## Best practices and tips
+
+* Enable **Parse first row as headers** whenever the incoming CSV includes field names; it makes downstream expressions easier to understand.
+* Use a custom delimiter only when the source data actually requires it.
+* If the input may contain uneven rows, decide explicitly whether padding mismatched rows is safer than failing early.
+
+## Related jobs
+
+* [forEachResourceStart.md](forEachResourceStart.md)
+* [csvPipeline.md](csvPipeline.md)
+* [parseJsonToResource.md](parseJsonToResource.md)
+
+## References
+
+* [Parse CSV to Resource](https://help.bosbec.com/knowledge-base/parse-csv-to-resource/)
+	* Complete property guide and examples for accessing CSV resources.
+* [For Each Resource](https://help.bosbec.com/knowledge-base/for-each-resource/)
+	* Useful when iterating through parsed CSV rows one item at a time.
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for workflow expressions used in source and downstream access syntax.

--- a/parseJsonToResource.md
+++ b/parseJsonToResource.md
@@ -1,14 +1,49 @@
-# Parse Json to Resource
+# Parse JSON to Resource
 
-_This job will parse a json in the "Json source" either from a resource/metadata or just as json-input.  
-The result is a json resource in the workflow context._
+The Parse JSON to Resource job parses JSON text from a workflow value and creates a JsonResource in the workflow context. Use it when incoming payloads, metadata values, or other resources contain JSON that should be accessed as structured data later in the workflow.
 
 ## Properties
-* **Json source*** - (input) A value with a json eg. _{"sample" : "json"}_ or a reference to a resource (could for example be a UnitResource) or metadata in the workflow context _metadata.my_json_
-* **Destination resource name*** - (output) A name for the created json resource.
 
-## Other
+The properties for configuring the parser are described below.
 
-The job will parse a JSON and if successful a JsonResource will be created in the workflow context.  
-To use and access data in the json use dot-notation eg. from a simple json _{"sample" : "value"}_ in a resource called _my_json_ you could access the value with **my_json.sample**.  
-See documentation about resources and JsonResource for more in-depth understanding.
+* **JSON source** (required)
+	* Source containing the JSON text to parse. This can be a raw JSON string or a workflow expression such as `{{incomingmessage.body}}` or `{{metadata.my_json}}`.
+* **Destination resource name** (required)
+	* Name of the JsonResource created in the workflow context.
+* **Deny lookup destination resource name** (optional)
+	* If enabled, the destination resource name is used exactly as entered instead of being resolved as a lookup.
+
+## Referencing syntax
+
+After parsing, access values using dot notation on the destination resource.
+
+* For `{"sample":"value"}` stored as `my_json`, use `{{my_json.sample}}`.
+* Nested values can be accessed with deeper paths such as `{{my_json.customer.id}}`.
+* For arrays, use index syntax such as `{{my_json.items[0].name}}`.
+
+## Resulting resource
+
+If parsing succeeds, the job creates a JsonResource in the workflow context.
+
+* The destination resource can be used directly in later jobs.
+* Downstream jobs can read specific properties without reparsing the JSON.
+* Invalid JSON input causes the parse to fail, so it is usually best to validate or isolate the source first when the payload may be inconsistent.
+
+## Best practices and tips
+
+* Give the destination resource a descriptive name so downstream expressions stay readable.
+* Parse once and reuse the resulting JsonResource instead of repeatedly handling the same payload as plain text.
+* When the JSON contains arrays, keep extraction expressions simple and move advanced array filtering into dedicated steps only when needed.
+
+## Related jobs
+
+* [parseCsvToResource.md](parseCsvToResource.md)
+* [parseXmlToResource.md](parseXmlToResource.md)
+* [jsonPipeline.md](jsonPipeline.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for workflow expressions and resource access syntax.
+* [Accessing Values Inside JSON Arrays](https://help.bosbec.com/knowledge-base/accessing-values-inside-json-arrays/)
+	* Examples of reading nested JSON arrays and filtering array items.

--- a/placeHolder.md
+++ b/placeHolder.md
@@ -1,1 +1,32 @@
-# Place holder #
+# Place holder
+
+The Place holder job performs no action on its own. Use it as a visible routing point, a temporary stub while building a workflow, or a clear end point for paths such as error handling where you want the workflow design to stay explicit.
+
+## Properties
+
+This job has no configurable properties.
+
+## Execution behavior
+
+The job does not read or write workflow data.
+
+* It simply passes execution to the next connected jobs.
+* It can be used to reserve a place for future logic without changing the current workflow path.
+* It is often useful on branches that should exist explicitly, even when no processing is needed yet.
+
+## Best practices and tips
+
+* Use a Place holder job when you want to make workflow branches readable without introducing temporary logic.
+* Keep the job name or description meaningful so it is obvious why the branch exists.
+* Use this job on success or failure paths when you want the destination of a route to stay visible during design and review.
+
+## Related jobs
+
+* [setDebugMode.md](setDebugMode.md)
+* [sendHttpRequest.md](sendHttpRequest.md)
+* [routeFromMetaData.md](routeFromMetaData.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful background when a placeholder marks a branch that will later read or write workflow context values.

--- a/resetSynchronizedCounter.md
+++ b/resetSynchronizedCounter.md
@@ -1,1 +1,54 @@
+# Reset Synchronized Counter
+
+The Reset Synchronized Counter job resets an existing synchronized counter to a specific value. Use it together with [synchronizedCounter.md](synchronizedCounter.md) when a quota, rate limit, or event counter should be cleared or reinitialized between periods, workflows, or business events.
+
+## Properties
+
+The properties for configuring the reset are described below.
+
+* **Counter name** (required)
+	* Logical name of the counter to reset.
+* **Counter key** (required)
+	* Unique key within the counter name that identifies which counter instance should be reset.
+* **Use counter for administrator** (optional)
+	* Use another administrator context when resolving which counter to reset.
+* **Reset value** (required)
+	* Value the counter should be set to after the reset.
+* **Counter limit** (optional)
+	* New counter limit to apply at the same time as the reset.
+
+## Referencing syntax
+
+Counter identifiers and reset values can be configured with dynamic workflow expressions.
+
+* Use expressions such as `{{metadata.sender}}` to target a specific counter key.
+* Use workflow values in **Reset value** when the counter should be reset to something other than a fixed number.
+* Use **Use counter for administrator** when the counter belongs to another administrator context on the same account.
+
+## Reset behavior
+
+This job updates an existing synchronized counter rather than incrementing it.
+
+* **Counter name** and **Counter key** identify which counter should be reset.
+* **Reset value** defines the new current value of that counter.
+* **Counter limit** can also be changed during the reset if the limit should be updated for future executions.
+
+This makes the job useful for resetting counters at the start of a new period, after a successful workflow branch, or when a manual override is needed.
+
+## Best practices and tips
+
+* Use the same **Counter name** and **Counter key** conventions here as in [synchronizedCounter.md](synchronizedCounter.md) so the intended counter is reset reliably.
+* Reset counters deliberately at clear lifecycle boundaries such as daily quotas, campaign restarts, or successful completion of a guarded process.
+* Update **Counter limit** only when the reset should also change the future threshold, not just the current value.
+
+## Related jobs
+
+* [synchronizedCounter.md](synchronizedCounter.md)
+* [findCounters.md](findCounters.md)
+* [routeFromMetaData.md](routeFromMetaData.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for building dynamic counter names, keys, and reset values from workflow data.
 

--- a/routeFromMetaData.md
+++ b/routeFromMetaData.md
@@ -1,30 +1,68 @@
-# Route From MetaData   #
+# Route From Meta Data
 
-*This job evaluates the configured routes and chooses what jobs to continue executing. Each route is a new
-evaluation and a way for the workflow to continue execution with the given series of jobs*
+The Route From Meta Data job branches workflow execution based on metadata values in the workflow context. Use it when different sets of jobs should run depending on comparisons such as status values, text matches, numbers, dates, or time windows.
 
-Use this job if you want the workflow to execute different jobs depending on given criteria.  
-For example if you have two **metadata** with different date-times, lets call them **metadata.last-ok** and **metadata.last-test**.   
-Then we create a MetaDataRoute within this job.   
-We want one set of jobs to be executed when **metadata.last-test** is later than **metadata.last-ok**.  
-The settings for that MetaDataRoute should be *Meta data source* should be set to **metadata.last-test** and *Compare value source* should be set to **metadata.last-ok**. And to make the comparison test that the first metadata (**metadata.last-test**) is later than the **metadata.last-ok** we will set the *Compare operator* to **>** meaning that the source should be bigger than the value we compare it to.    
-If we want something else to happen when this comparison doesn't match we connect another set of jobs to the **Route destination on no match** that is available when hovering over the job.  
+## Properties
 
+The properties for configuring the job are described below.
 
-When the job has two routes that are not exclusive, meaning that two or more routes can be true/matched at the same time.  
-Example: route1 compares a number that may be between 1-5 while route2 compare if a number is exactly 3. Both will be true and match.  
-What happens is that the workflow will behave in a way that execute first from route1 and then route2.  
-If this is something that you want to do, then you will probably want to split the workflow, using the checkbox to split on each matching route.  
+* **Meta data routes** (required)
+	* List of route definitions. Each route contains a metadata source, a compare operator, and either a static compare value or a compare value source.
+* **Route destination on no match** (optional)
+	* Fallback path used when none of the configured routes match.
+* **Split workflow context on multiple matches** (optional; default: false)
+	* If enabled, the workflow context is split when several routes match so each route continues in its own context.
 
-For more information about what operators are available and how to use them, please read the section on @{text:Comparing MetaData;link:metaDataComparison}@   
-For more information about metadata and how to use it during workflow execution, please refer to the section on @{text:Workflow Context;link:workflowContext}@   
+## Referencing syntax
 
-**Notes:   
-The jobs connected from the "Jobs"-connector will not be executed.   
-Multiple matching routes at the same time may cause unexpected behaviour**
+Route definitions usually compare workflow metadata or other dynamic values.
 
-**How to:**  
-Create as many metadata routes as you need and set up the evaluation for each of them.  
-Connect one or more jobs to each evaluation and they will be executed after evaluation matches.  
-Connect to the RouteDestinationOnNoMatch to catch every other case when none of the
-evaluation matches.  
+* Read metadata with `{{metadata.key}}`.
+* Use **Compare value source** when the value to compare against should also come from metadata or another resource, for example `{{metadata.last_ok}}`.
+* Use date expressions such as `{{datetime(yyyy-MM-dd)}}` when working with time-based routes.
+
+## Route behavior
+
+Each route evaluates one condition.
+
+* **Meta data source**
+	* The value to evaluate, for example `{{metadata.status}}`.
+* **Compare operator**
+	* Determines how the comparison is performed, for example `=`, `>`, `contains`, `before`, or `regex`.
+* **Compare value**
+	* Static comparison value such as `OK`.
+* **Compare value source**
+	* Dynamic comparison value read from workflow context.
+
+For example, if `{{metadata.last_test}}` should be later than `{{metadata.last_ok}}`, set the metadata source to `{{metadata.last_test}}`, the compare value source to `{{metadata.last_ok}}`, and the operator to `>`.
+
+## Multiple matches
+
+Several routes can match during the same execution.
+
+* Without **Split workflow context on multiple matches**, matching routes continue one after another in the same workflow context.
+* With **Split workflow context on multiple matches** enabled, each matching route gets its own workflow-context copy, which reduces interference between branches.
+* Jobs connected to route outputs are the paths that execute. The ordinary `Jobs` connector is not used for route matches.
+
+## Best practices and tips
+
+* Use **Route destination on no match** to make the fallback behavior explicit.
+* Avoid designing routes so that multiple branches match at the same time when possible.
+* When the logic can be expressed as a sequence of decisions, prefer chaining multiple [routeFromMetaData.md](routeFromMetaData.md) jobs instead of relying on several matches in a single job. This reduces the risk of race conditions or conflicting workflow-context changes further downstream.
+* Enable **Split workflow context on multiple matches** when several routes may match and the branches should not modify the same workflow context.
+* Prefer **Compare value source** over copying values into static fields when both sides of the comparison are dynamic.
+
+## Related jobs
+
+* [executeWorkflow.md](executeWorkflow.md)
+* [filterWorkflowContext.md](filterWorkflowContext.md)
+* [metaDataComparison.md](metaDataComparison.md)
+
+## References
+
+* [Route From Meta Data](https://help.bosbec.com/knowledge-base/route-from-meta-data/)
+	* Detailed examples of metadata routes, time-based routes, and multiple-match behavior.
+* [Comparison Operators](https://help.bosbec.com/knowledge-base/comparison-operators/)
+	* Complete list of supported operators and how they behave.
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for metadata expressions and date/time functions.

--- a/saveToGroup.md
+++ b/saveToGroup.md
@@ -1,22 +1,60 @@
-# Save to group #
+# Save To Group
 
-*This job can create groups and save group members to the given group.*
+The Save To Group job saves members from the workflow context into a group. It can target an existing group or create a new group, including a dynamic group based on tags.
 
+## Properties
 
-If you want to create a new group set the “CreateNewGroupAndIgnoreGroupId” to true. This will ignore what is connected in WF-builder.  
-Set NewDynamicGroupTagsSource to a WFC-resource that contains a comma-separated list of tags to include if you want to create a dynamic group with the given tags.    
+The properties for configuring the job are described below.
 
+* **Group** (optional)
+	* Existing group to save members into.
+* **Use workflow context groups** (optional; default: false)
+	* Use members from all workflow-context groups.
+* **Create new group and ignore group ID** (optional; default: false)
+	* Create a new group instead of using the connected group.
+* **New group name source** (optional)
+	* Name for the new group when a group is being created.
+* **New dynamic group tags source** (optional)
+	* Comma-separated tag list used when creating a dynamic group.
+* **Use workflow context temporary group** (optional; default: false)
+	* Use members from the workflow-context temporary group.
+* **Use incoming unit** (optional; default: false)
+	* Use the incoming unit as a group member source.
+* **Resource name** (optional)
+	* Destination resource where the resulting group ID is stored.
 
-If you do not want to create a new group, then connect a group in WF-builder.  
+## Referencing syntax
 
-If you want to save members from WF-groups set “Use workflow context groups” to true.  
-If you want to save members from WF-temporary group set “Use workflow context temporary group” to true.  
+When creating new groups dynamically, the name and tag values can come from workflow data.
 
+* Use workflow expressions such as `{{metadata.group_name}}` in **New group name source**.
+* Use a comma-separated source such as `tag-a,tag-b` for **New dynamic group tags source**.
 
-**Notes:   
-Can both create new groups/dynamic groups and save to an existing group.**
+## Behavior
 
-**How to:**  
-Chose if to create a new group or connect to an existing.  
-Select what members to save to group. 
+This job supports two main modes.
+
+* **Save to an existing group**
+	* Connect a group and choose which members from workflow context should be added.
+* **Create a new group**
+	* Enable **Create new group and ignore group ID** and provide a group name.
+
+If dynamic-group tags are provided while creating a new group, the created group behaves as a dynamic group rather than a purely static one.
+
+## Best practices and tips
+
+* Use only the member sources you actually need so the result is predictable.
+* When creating a dynamic group, keep the tag source stable and easy to audit.
+* Save the resulting group ID to a resource when later jobs need to reference the created group explicitly.
+
+## Related jobs
+
+* [groupOperations.md](groupOperations.md)
+* [unitOperations.md](unitOperations.md)
+* [findGroups.md](findGroups.md)
+
+## References
+
+* [Importing units](https://help.bosbec.com/knowledge-base/importing-units/)
+	* Useful background when group members come from newly created or loaded unit data.
 

--- a/sendMessageToGroups.md
+++ b/sendMessageToGroups.md
@@ -1,16 +1,60 @@
-# Send message to groups #
+# Send Message To Groups
 
-*This job sends the message (connected message template) to the connected groups or defaults to WFC-groups and WFC-temporary groups.*
+The Send Message To Groups job sends a message template to one or more groups. If no explicit groups are connected, it can fall back to groups and units already present in the workflow context.
 
-If there are no groups connected, the job will find receivers in WFC-temporary group and WFC-groups.
-Fixes some default-settings for app-messages, such as setting the inbox and sender id to a default value from merged settings (see section on merged settings for more information).
+## Properties
 
+The properties for configuring the send are described below.
 
+* **Message** (optional)
+	* Connected message template to send.
+* **Groups** (optional)
+	* Explicit groups to receive the message.
+* **Send only to active units** (optional; default: false)
+	* If enabled, only active units in the target groups are used as recipients.
+* **Use workflow context units** (optional; default: false)
+	* Include units already present in the workflow context.
+* **Override message text** (optional)
+	* Replace the message template body with a custom value.
+* **Override form template ID** (optional)
+	* Override the form template used in the message.
+* **Message resource** (optional)
+	* Message resource to use instead of a directly connected message template.
+* **Add files as metadata for app messages** (optional; default: false)
+	* Attach workflow files as metadata for app-message sends.
+* **Ignore send if no receivers** (optional; default: false)
+	* Skip the send without raising an account error when no recipients are found.
 
-**Notes:   
-Sets defaults for MessageTemplates (only app-message in this case)
-Defaults to WFC-groups and WFC-temporary group.**
+## Referencing syntax
 
-**How to:**  
-Set the message tempalate.  
-(Optionally) Set the groups.
+Use workflow expressions when overriding message content dynamically.
+
+* Use **Override message text** for runtime-specific content.
+* Use **Message resource** when the message template was loaded or created earlier in the workflow.
+
+## Receiver selection
+
+The job can gather recipients from several places.
+
+* Use explicitly connected groups when the audience is known in advance.
+* If no groups are connected, the job can default to workflow-context groups and the temporary group.
+* Enable **Use workflow context units** when units already loaded into workflow context should also be considered.
+
+For app messages, the job also applies default app-message settings such as sender and inbox values from merged settings when needed.
+
+## Best practices and tips
+
+* Connect groups explicitly when the intended audience should be obvious from the workflow design.
+* Use **Ignore send if no receivers** only when an empty recipient set is expected and should not be treated as an error.
+* Keep message selection clear: use either a connected message template or a message resource when possible, rather than mixing both patterns unnecessarily.
+
+## Related jobs
+
+* [messageTemplate.md](messageTemplate.md)
+* [sendMessageToUnits.md](sendMessageToUnits.md)
+* [findMessageTemplateAsResource.md](findMessageTemplateAsResource.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful when overriding message text or selecting a message resource dynamically.

--- a/setDebugMode.md
+++ b/setDebugMode.md
@@ -1,1 +1,36 @@
+# Set Debug Mode
+
+The Set Debug Mode job is used to pause workflow execution so you can inspect the current state and step through the workflow manually during troubleshooting. In practice, it behaves like a breakpoint placed directly in the workflow.
+
+## Properties
+
+The properties for configuring the job are described below.
+
+* **Debug mode** (optional; default: false)
+	* Set to `true` to pause execution at this point in the workflow. Set to `false` when you want the workflow to continue without stopping here.
+
+## Execution behavior
+
+This job affects the currently running workflow execution only.
+
+* When **Debug mode** is enabled, execution pauses at this job so you can inspect the workflow state and continue step by step.
+* When **Debug mode** is disabled, execution passes through the job without stopping.
+* This job is useful when you want the breakpoint to exist as a visible job in the workflow itself.
+
+## Best practices and tips
+
+* Place the job immediately before the part of the workflow you want to inspect.
+* Remove it or disable **Debug mode** after troubleshooting so normal workflow runs do not stop unexpectedly.
+* There is now also an alternative breakpoint mechanism in the workflow builder: click the arrow between two jobs and select `Set breakpoint`.
+* Use the arrow-based breakpoint when you want a lighter-weight breakpoint without adding a dedicated job to the workflow.
+
+## Related jobs
+
+* [placeHolder.md](placeHolder.md)
+* [executeWorkflow.md](executeWorkflow.md)
+
+## References
+
+* [Getting started: Integrations](https://help.bosbec.com/knowledge-base/getting-started-integrations/)
+	* Background guidance for troubleshooting and validating workflow-based integrations.
 

--- a/synchronizedCounter.md
+++ b/synchronizedCounter.md
@@ -1,42 +1,72 @@
-# Synchronized counter #
+# Synchronized Counter
 
-*This job is a counter, and the synchronized-part of the name indicates that it will synchronize the counting even if there are many workflows that simultaneously want to increase the counter.*
+The Synchronized Counter job increments a shared counter safely even when many workflows run in parallel. Use it to enforce quotas, count events, or rate-limit actions where concurrent workflow executions must not overwrite each other.
 
-The counter name is just the name of a counter and in combination with the counter key it creates a unique counter with a counter limit and current value and so on.  
-For example, if I want my counter to limit the executions per incoming email address, I would set up a counter with the name **emailcounter** and dynamically use the different email sender addresses as a key.  
+## Properties
 
-> So if sender1@mobileresponse.io sends email to the workflow the counter **emailcounter + sender1@mobileresponse.io** will increase its current value, but the counter **emailcounter + another_sender@mobileresponse.io** will not increase.
+The properties for configuring the counter are described below.
 
-**CounterName**, **CounterKey**, **CounterLimit**, **RequestedIncrement**, **MinIncrementChunkSize** can all be set either as the value direct or set as a WFC-resource containing the value.  
-*RequestedIncrement* and *MinIncrementChunkSize* will default to 1 if no other valid value is set.
+* **Counter name** (required)
+	* Logical name of the counter.
+* **Counter key** (required)
+	* Unique key within the counter name, often built from a dynamic business value such as an email address or customer ID.
+* **Counter limit** (optional)
+	* Maximum allowed value. Leave empty if the counter should not have a limit.
+* **Counter limit must be set** (optional; default: false)
+	* Requires a limit to exist when the job runs.
+* **Requested increment** (optional; default: 1)
+	* Preferred amount to add during this execution.
+* **Min increment chunk size** (optional; default: 1)
+	* Smallest partial increment allowed when the requested increment would cross the limit.
+* **Output value** (required)
+	* Destination where the current counter value is written after execution.
+* **Output result** (required)
+	* Destination where the result text is written after execution.
+* **Use counter for administrator** (optional)
+	* Use another administrator context when resolving the counter.
 
+## Referencing syntax
 
+Counter values and outputs can be configured with dynamic workflow expressions.
 
-When the counter is executed, it will produce a result and a current value that can be put in any available workflow metadata or equivalent resource.
-The results are:
+* Use expressions such as `{{metadata.sender}}` to build a per-sender **Counter key**.
+* Write the result destinations to metadata or another writable destination so later jobs can route on them.
+* Use dynamic sources for **Requested increment** when the increment depends on runtime data.
 
-- OK – which means that increasing the current value for the counter was OK, no limit was reached or already passed. Ex. the limit is 10 and the counter is now 3.
-- Limit reached – which means that there are no more room to continue counting. Ex. the limit was 10 and the counter is now 10.
-- Fail – means that it is not possible to increase the counter, and no increment has been made. Ex. limit was 10, counter value was 10 before trying to increase, counter value is 10 after job execution as well.
+## Result values
 
-Another thing to mention here is that the RequestedIncrement and MinIncrementChunkSize can be for some cases when counting.   
-The RequestedIncrement is how much we want to increase the counter with at the time of execution. (It can be a dynamic value from a WFC resource or a fixes value configured on the job).  
-For example RequestedIncrement can by 2 and each time the counter is executed the value will increase with 2. Ex. **First execution: 2**, **Second execution 4** …  
+The job stores both the counter value and a result value.
 
-MinIncrementChunkSize, on the other hand is used together with the RequestedIncrement. It tells the job if it is allowed to increase the counter-value by a part of the RequestedIncrement.  
-So if the RequestedIncrement is 2, but the MinIncrementChunkSize is 1 it means that such a counter can have an odd number (ex. 3) as limit, even though we increase it with 2 (most of the time). Ex. **First execution: 2**, **Sencond execution**: *cannot increase with RequestedIncrement (2), will attempt a smaller chunk (1), and that works result:* **3**
+* **OK**
+	* The increment succeeded and the limit was not exceeded.
+* **Limit reached**
+	* The counter reached the configured limit.
+* **Fail**
+	* No increment was made, usually because the counter was already at or above the limit.
 
+The workflow continues after the job even when the result is `Limit reached` or `Fail`, so the result should be used in later routing or execution rules.
 
+## Increment behavior
 
-**Notes:   
-The job will execute next jobs even if the result is Limit reached or Fail, and you need to use the result in ExeccutionRules or MetadataRoutes.  
-For now this job is designed to be used with counting “up”, that is +, adding and increasing the numbers.**
+The job counts upward only.
 
-**Tip: Use in combination with the ResetSynchronizedCounter job!**
- 
+* **Requested increment** controls how much the counter should increase.
+* **Min increment chunk size** allows a smaller final increment when the full requested increment would exceed the limit.
+* Example: with a limit of `3`, a requested increment of `2`, and a minimum chunk size of `1`, the counter can move from `2` to `3` on the final execution.
 
+## Best practices and tips
 
-**How to:**
-Set a counter name (usually you will just need one counter name for a workflow, since you have counter key to make it unique within a workflow)
-Set the counter key, counter limit... and the other properties as described above.
-Remember to set the output value and result to make use of it when routing after the job is executed.
+* Keep **Counter name** stable and use **Counter key** for the runtime-specific uniqueness.
+* Always store **Output value** and **Output result** so later jobs can decide what to do.
+* Pair this job with [resetSynchronizedCounter.md](resetSynchronizedCounter.md) when the counter should be reset between periods or workflows.
+
+## Related jobs
+
+* [resetSynchronizedCounter.md](resetSynchronizedCounter.md)
+* [findCounters.md](findCounters.md)
+* [routeFromMetaData.md](routeFromMetaData.md)
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Reference for building dynamic counter keys, increments, and output destinations from workflow data.

--- a/unitOperations.md
+++ b/unitOperations.md
@@ -1,34 +1,92 @@
-# Unit operations #
+# Unit Operations
 
-*This job can perform operations related to units. Eg. get units, move within workflow context...*
+The Unit Operations job lets you find units from one or more sources, optionally filter the result, optionally update the found units, and finally decide how those units should be stored or deleted.
 
+## Properties
 
-There are a number of different operations to choose between and the basic concept is:  
-1.  Find units from one or more sources; could be from account or from within the current execution of the workflow. Each additional find-operation will not modify what was found, but add to the set of found units.  
-2. Filter the units that were found in the first step(s); each filter will continue working with a subset of units that was the result from previous filter-step(s).  
-3. The store-operation can be used to either put the found+processed units in a destination such as the temporary group in the current execution or used to remove units eg. from the account.   
+The job is organized into stages rather than a single flat property list.
 
+* **Find operations** (required)
+	* Ordered list of find steps that add units to the working set.
+* **Filter operations** (optional)
+	* Ordered list of filters applied to the found units.
+* **Operate on units** (optional)
+	* Ordered list of operations to perform on the units, such as updating metadata.
+* **Store operation** (required)
+	* Final step that decides how the processed units are stored, persisted, or deleted.
 
+## Referencing syntax
 
-**Notes:**
+Expressions in filters and updates usually compare unit data with workflow data.
 
-Find-steps can be unsuccessful, and a setting to continue on error must be set if that is the desired behaviour.**
+* Read unit metadata with expressions such as `{{unit.metadata.customer_id}}`.
+* Read workflow context metadata with expressions such as `{{metadata.customer_id}}`.
+* When updating unit metadata, use unit destinations on the left side and workflow values or static values on the right side.
 
-**How to:**
+## Find operations
 
-Add one or more find-operations to get units to process, optionally you may filter the given units before you let the job store or delete the resulting units from a given destination. 
+Find steps append units to the working set instead of replacing earlier results.
 
+Common find patterns include:
 
-**Find Operations**
+* **Find from account**
+	* Search the account by phrase, including metadata-aware search such as `md:firstname=John`.
+* **Find by phone** or **Find by email**
+	* Search with a direct channel value.
+* **Find in group**
+	* Load units from a specific group.
+* **Find in resource**
+	* Load units from one or more workflow resources.
+* **Find in workflow context**
+	* Reuse units already present in the temporary group or workflow groups.
+* **Create from data**
+	* Create units directly from workflow values.
 
-FindFromAccount: Search for whole "words" such as **John Doe**, and the search will look for **John** OR **Doe**. To search for exact phrase **"John Doe"** use quotation marks around the whole phrase you expect to search for. To search for John as first name, prefix the search with **md:** for metadata and **firstname=** the meta data key; **"md:firstname=John"**. Words in quotation marks must all be present to be included in the found units. !Tip: Use a combination of find-operations and filter the result before store!
+Each step has an order and can be configured to continue on error if partial success is acceptable.
 
-**Metadata filter**
+## Filter operations
 
-* To compare data found on the unit, use the following format: unit.metadata.key
-* To compare data found on the workflow, use: metadata.key
+Filters narrow down the current working set.
 
-**Operate - Update meta data**
+* **Channel filter**
+	* Keep or remove units based on available channels.
+* **Metadata filter**
+	* Compare unit values against static values or workflow values.
 
-* To assign a metadata in the left column, use the following format: unit.metadata.key
-* To retrieve a value from the workflow context metadata in the right column (get a value), use: metadata.key
+Use filters after broad find steps when you want a more readable pipeline than building one very complex search expression.
+
+## Operate on units
+
+The most common operation is metadata updates.
+
+* **Update metadata**
+	* Apply key-value updates to all units currently in the working set.
+
+This is useful when a workflow should enrich units before saving them to the account, groups, or resources.
+
+## Store operation
+
+The final step decides what happens to the resulting units.
+
+Typical outcomes include saving to the account, saving to a workflow resource, saving to workflow groups or the temporary group, or deleting units from the account.
+
+## Best practices and tips
+
+* Use several small find and filter steps instead of one overloaded search when readability matters.
+* Turn on continue-on-error only when the workflow can safely proceed with partial results.
+* When deduplication or merging is the real goal, compare this job with [unitPipeline.md](unitPipeline.md) before choosing an approach.
+
+## Related jobs
+
+* [unitPipeline.md](unitPipeline.md)
+* [findOrCreateUnits.md](findOrCreateUnits.md)
+* [saveToGroup.md](saveToGroup.md)
+
+## References
+
+* [Unit Pipeline – Merging Units](https://help.bosbec.com/knowledge-base/unit-pipeline-merging-units/)
+	* Related guidance when the unit workflow involves deduplication or merging.
+* [Importing units](https://help.bosbec.com/knowledge-base/importing-units/)
+	* Background on common unit data patterns and bulk import behavior.
+* [Comparison Operators](https://help.bosbec.com/knowledge-base/comparison-operators/)
+	* Reference for the operators used in metadata-based unit filters.


### PR DESCRIPTION
This pull request introduces significant improvements to the workflow job documentation. It adds new documentation files, standardizes the format, enhances clarity, and removes outdated or redundant details. The most notable changes are the introduction of a documentation update tracker, new and improved job documentation files, and the removal of the unnecessary "Order" property from the `dataOperations.md` job steps.

**Documentation infrastructure and format:**

* Added a new `JOBS_UPDATED.md` file to track documentation updates for all job files, including an update history table, a template for future documentation, and sections for planned updates.

**New and improved job documentation:**

* Added new documentation file `addWorkflowStartsTag.md` describing the Add Workflow Starts Tag job, including its properties, referencing syntax, execution behavior, best practices, related jobs, and references.
* Rewrote and expanded `answerSender.md` to clarify the purpose, configuration, sender selection logic, best practices, related jobs, and references for the Answer Sender job.
* Rewrote and expanded `clearWorkflowContext.md` to clearly explain the Clear Workflow Context job, its properties, referencing syntax, cleanup behavior, best practices, related jobs, and references.

**Standardization and cleanup of job properties:**

* Removed the redundant **Order** property from all operation steps in `dataOperations.md`, simplifying the documentation and focusing on relevant configuration options. [[1]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL44-L45) [[2]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL57-L58) [[3]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL74-L75) [[4]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL91-L92) [[5]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL104-L105) [[6]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL123-L124) [[7]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL142-L143) [[8]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL153-L154) [[9]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL164-L165) [[10]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL181-L182) [[11]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL198-L199) [[12]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL211-L212) [[13]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL228-L229) [[14]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL239-L240) [[15]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL254-L255) [[16]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL269-L270) [[17]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL280-L281) [[18]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL291-L292) [[19]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL312-L313) [[20]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL323-L324) [[21]](diffhunk://#diff-9c3505a4306c2d5f190fc9b9169c9114e2fa076803bc78aa7ef70bdb31f772aeL350-L351)

These changes help make the documentation more consistent, easier to maintain, and more useful for workflow developers.