### PR TITLE
Normalize 'Related jobs' link titles

### DIFF
--- a/JOBS_UPDATED.md
+++ b/JOBS_UPDATED.md
@@ -11,6 +11,9 @@ This file tracks all job documentation updates and changes.
 | clearWorkflowContext.md | 2026-03-24 |
 | synchronizedCounter.md | 2026-03-24 |
 | resetSynchronizedCounter.md | 2026-03-24 |
+| findUnitsById.md | 2026-03-24 |
+| extractData.md | 2026-03-24 |
+| createJwtSigning.md | 2026-03-24 |
 | forEachResourceStart.md | 2026-03-24 |
 | forEachResourceStop.md | 2026-03-24 |
 | parseJsonToResource.md | 2026-03-24 |

--- a/addWorkflowStartsTag.md
+++ b/addWorkflowStartsTag.md
@@ -33,9 +33,9 @@ This job updates the current workflow-start record rather than a unit, group, or
 
 ## Related jobs
 
-* [executeWorkflow.md](executeWorkflow.md)
-* [notifyUi.md](notifyUi.md)
-* [workflow.md](workflow.md)
+* Execute Workflow
+* Notify UI
+* Workflow
 
 ## References
 

--- a/answerSender.md
+++ b/answerSender.md
@@ -38,9 +38,9 @@ The job also aborts if the sender unit cannot be resolved.
 
 ## Related jobs
 
-* [answerFormQuestion.md](answerFormQuestion.md)
-* [sendMessageToGroups.md](sendMessageToGroups.md)
-* [messageTemplate.md](messageTemplate.md)
+* Answer Form Question
+* Send Message To Groups
+* Message templates
 
 ## References
 

--- a/clearWorkflowContext.md
+++ b/clearWorkflowContext.md
@@ -47,9 +47,9 @@ Each option affects a different part of the workflow context.
 
 ## Related jobs
 
-* [filterWorkflowContext.md](filterWorkflowContext.md)
-* [splitWorkflowContext.md](splitWorkflowContext.md)
-* [workflowContext.md](workflowContext.md)
+* Filter Workflow Context
+* Split Workflow Context
+* Workflow Context
 
 ## References
 

--- a/createJwtSigning.md
+++ b/createJwtSigning.md
@@ -1,0 +1,47 @@
+# Create JWT Signing
+
+The Create JWT Signing job creates a signed JWT (JSON Web Token) by signing a payload with a private key. Use it when a workflow needs to generate a token for authenticating against an external API or for sending signed claims to another system.
+
+## Properties
+
+The properties for configuring the signing are described below.
+
+* **Payload** (required)
+	* JWT payload to sign. This is typically a JSON object containing the claims that should be included in the token.
+* **Private key** (required)
+	* Private key used to sign the JWT.
+* **Destination** (required)
+	* Workflow context destination where the signed JWT will be stored.
+
+## Referencing syntax
+
+Payload, key, and destination can be built from workflow values.
+
+* Use expressions such as `{{metadata.claims_json}}` when the payload is prepared earlier in the workflow.
+* Use expressions such as `{{metadata.private_key}}` if the private key is resolved from workflow context.
+* Store the result in a destination that later jobs can reference, for example a metadata key used by a request-building step.
+
+## Signing behavior
+
+The job signs the provided payload and writes the resulting token to the chosen destination.
+
+* The **Payload** should contain the claims required by the target system.
+* The **Private key** must be the key material expected by the signing implementation.
+* The resulting token can then be inserted into headers, request bodies, or other workflow values.
+
+## Best practices and tips
+
+* Build and validate the payload before signing so the resulting token contains only the claims you intend to send.
+* Store private keys securely and inject them from controlled workflow sources rather than hardcoding them broadly in multiple jobs.
+* Use a clear destination name so later HTTP or API jobs can reference the signed token without ambiguity.
+
+## Related jobs
+
+* Send HTTP Request
+* Verify JWT
+* Extend Token Expiration
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful when building JWT payloads or storing the resulting token in workflow context.

--- a/executeWorkflow.md
+++ b/executeWorkflow.md
@@ -49,10 +49,10 @@ The job searches for the target workflow, starts it, and then continues based on
 
 ## Related jobs
 
-* [routeFromMetaData.md](routeFromMetaData.md)
-* [executeOrPostpone.md](executeOrPostpone.md)
-* [workflow.md](workflow.md)
-* [addWorkflowStartsTag.md](addWorkflowStartsTag.md)
+* Route From Meta Data
+* Execute Or Postpone
+* Workflow
+* Add Workflow Starts Tag
 
 ## References
 

--- a/extractData.md
+++ b/extractData.md
@@ -1,19 +1,61 @@
-# Extract Data #
+# Extract Data
 
-*This job is built to extract data from events or complex resources, for example when import is finished, when a dynamic group creation is finished. Another example is to move group members from the workflow groups to the WFC temporary group.*
+The Extract Data job pulls structured data out of events or workflow resources and moves it into workflow context in a form that later jobs can use. Use it when a trigger or process event contains groups, members, form answers, metadata, or units that should be promoted into workflow groups, temporary group, resources, or metadata.
 
-There are three different features available at this moment (and you can set them either by the exact name or the number):
-* GetGroupFromImportFinishedProcessEvent
-  * Gets the group(s) from the ImportFinished-event and adds the group to the workflow groups (NOTE: not to the temporary group)
-* MoveWorkflowGroupMembersToTemporaryGroup
-  * Reads the group-members from the workflow groups, removes those groups from the current execution and adds all members from the workflow groups to the WFC temporary group instead. (This is done so that you may apply WFC temporary group-filters)
-  * Unit resource will have a name like unit-resource-1 where the job will try not to overwrite, so if unit-resource-1 exists it will use unit-resource-2
-* GetGroupFromDynamicGroupCreationFinishedEvent
-  * Just like (1), this extraction finds out what group was just compiled and adds that group(s) to the workflow groups (NOTE: not to the temporary group)
-  
-**Notes:
-Must manually enter one of the “extractions”.
-For some of the extractions (1 & 3) it is required that the execution is triggered by a process-trigger.**
+## Properties
 
-**How to:**
-Enter one of the actions/extractions and the job will do that.
+The properties for configuring the job are described below.
+
+* **From** (required)
+  * Extraction mode that decides what should be extracted and where the result should be placed.
+
+## Referencing syntax
+
+This job is mode-driven rather than expression-driven. You select one extraction mode and the job performs the corresponding action on the current workflow context.
+
+## Extraction modes
+
+The available extraction modes determine what kind of data is moved into workflow context.
+
+* **GetGroupFromImportFinishedProcessEvent**
+  * Extracts groups from an import-finished process event and adds them to workflow groups.
+* **MoveWorkflowGroupMembersToTemporaryGroup**
+  * Reads members from workflow groups, removes those groups from the current execution, and moves the members into the workflow context temporary group.
+* **GetGroupFromDynamicGroupCreationFinishedEvent**
+  * Extracts groups from a dynamic-group-creation-finished event and adds them to workflow groups.
+* **UpdateIncomingUnitWithFormAnswers**
+  * Updates the incoming unit with data from form answers.
+* **UpdateMetaDataWithFormAnswers**
+  * Writes form-answer data into workflow context metadata.
+* **MoveTemporaryGroupToUnitResourceExtraction**
+  * Moves units from the temporary group into a unit resource.
+* **MoveAllUnitResourcesToTemporaryGroup**
+  * Collects units from unit resources and moves them into the temporary group.
+* **GetMetaDataFromImportFinishedProcessEvent**
+  * Extracts metadata from an import-finished process event into workflow context.
+* **MoveIncomingUnitToTemporaryGroup**
+  * Adds the incoming unit to the temporary group.
+
+## Execution behavior
+
+The job performs exactly one extraction mode per execution.
+
+* Some event-based extractions require the workflow to have been triggered by a compatible process trigger.
+* Group-oriented extractions can place groups in workflow groups rather than the temporary group, depending on the mode.
+* Temporary-group and resource-move modes are useful when later jobs expect data in a specific workflow-context location.
+
+## Best practices and tips
+
+* Choose the extraction mode based on where downstream jobs expect to find the data: workflow groups, temporary group, metadata, or a resource.
+* Keep process-trigger-dependent modes near the relevant trigger flow so the required event data is still available and easy to understand.
+
+## Related jobs
+
+* Clear Workflow Context
+* Filter Workflow Context
+* Move Workflow Group Members To Temporary Group
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+  * Useful background for understanding where extracted metadata and resources end up in workflow context.

--- a/findMessageTemplateAsResource.md
+++ b/findMessageTemplateAsResource.md
@@ -42,9 +42,9 @@ The job finds matching templates and stores them in the named workflow resource.
 
 ## Related jobs
 
-* [createMessageTemplateAsResource.md](createMessageTemplateAsResource.md)
-* [messageTemplate.md](messageTemplate.md)
-* [sendMessageToGroups.md](sendMessageToGroups.md)
+* Create Message Template As Resource
+* Message templates
+* Send Message To Groups
 
 ## References
 

--- a/findOrCreateUnits.md
+++ b/findOrCreateUnits.md
@@ -49,10 +49,10 @@ The distinct options are useful when duplicate phone numbers or email addresses 
 
 ## Related jobs
 
-* [unitPipeline.md](unitPipeline.md)
-* [unitOperations.md](unitOperations.md)
-* [setIncomingUnit.md](setIncomingUnit.md)
-* [getUsersFromIncomingMessage.md](getUsersFromIncomingMessage.md)
+* Unit Pipeline
+* Unit Operations
+* Set Incoming Unit
+* Get Users From Incoming Message
 
 ## References
 

--- a/findUnitsById.md
+++ b/findUnitsById.md
@@ -1,18 +1,45 @@
-# Find Units by Id#
+# Find Units By ID
 
-*This job will find units by id and put in temporary group or resource if a resource name is provided.*
+The Find Units By ID job resolves one or more unit GUIDs into actual unit objects. Use it when you already know the unit IDs and want to load those units into the workflow context for later filtering, messaging, or saving.
 
-Will find Ids (Guid) in the given source.
+## Properties
 
-If the resource name is set then the result will end up as a unit-resource. Otherwise the result will end up in workflow context temporary group.
+The properties for configuring the lookup are described below.
 
-Using a standard delimiter or character like , or ; to separate Ids is preferred, but not a must.
+* **ID source** (required)
+	* Source containing one unit ID or multiple unit IDs. The value can come from workflow context and commonly uses comma- or semicolon-separated GUIDs.
+* **Resource name** (optional)
+	* Name of the output unit resource. If left empty, the found units are added to the workflow context temporary group instead.
 
+## Referencing syntax
 
-**Notes:**
+Use workflow expressions when the IDs come from metadata or another resource.
 
-Resource name will not get value from wfc.
+* `{{metadata.unit_id}}` can be used for a single known unit ID.
+* `{{metadata.unit_ids}}` can be used when a previous step stored several IDs in one value.
+* Comma-separated and semicolon-separated GUID lists are preferred when providing multiple IDs.
 
-**How to:**
+## Behavior
 
-Make sure the job has ids to search with and set the ResourceName if you want the result to be a wfc Resource.
+The job reads the ID value from **ID source** and resolves the matching units.
+
+* If **Resource name** is provided, the result is stored as a unit resource in workflow context.
+* If **Resource name** is left empty, the result is added to the workflow context temporary group.
+* This job is useful when later workflow steps need full unit objects rather than only their IDs.
+
+## Best practices and tips
+
+* Use a resource output when later jobs should work with the units as a named resource rather than through the temporary group.
+* Prefer consistent separators such as `,` or `;` when providing multiple IDs.
+* Keep ID lookup separate from broader search logic; if you need more flexible find behavior, compare this job with Find Or Create Units or Unit Pipeline.
+
+## Related jobs
+
+* Find Or Create Units
+* Unit Pipeline
+* Set Incoming Unit
+
+## References
+
+* [Working With Variables](https://help.bosbec.com/knowledge-base/working-with-variables/)
+	* Useful when unit IDs are read from metadata or workflow resources.

--- a/forEachResourceStart.md
+++ b/forEachResourceStart.md
@@ -40,9 +40,9 @@ When the loop reaches [forEachResourceStop.md](forEachResourceStop.md), executio
 
 ## Related jobs
 
-* [forEachResourceStop.md](forEachResourceStop.md)
-* [parseCsvToResource.md](parseCsvToResource.md)
-* [unitPipeline.md](unitPipeline.md)
+* For Each Resource Stop
+* Parse CSV to Resource
+* Unit Pipeline
 
 ## References
 

--- a/forEachResourceStop.md
+++ b/forEachResourceStop.md
@@ -25,9 +25,9 @@ This job does not process data by itself. Instead, it controls how the loop cont
 
 ## Related jobs
 
-* [forEachResourceStart.md](forEachResourceStart.md)
-* [parseCsvToResource.md](parseCsvToResource.md)
-* [unitPipeline.md](unitPipeline.md)
+* For Each Resource Start
+* Parse CSV to Resource
+* Unit Pipeline
 
 ## References
 

--- a/groupOperations.md
+++ b/groupOperations.md
@@ -44,9 +44,9 @@ The pipeline follows a consistent sequence.
 
 ## Related jobs
 
-* [saveToGroup.md](saveToGroup.md)
-* [group.md](group.md)
-* [unitOperations.md](unitOperations.md)
+* Save To Group
+* Groups
+* Unit Operations
 
 ## References
 

--- a/parseCsvToResource.md
+++ b/parseCsvToResource.md
@@ -51,9 +51,9 @@ If parsing succeeds, the job creates a CsvResource that downstream jobs can insp
 
 ## Related jobs
 
-* [forEachResourceStart.md](forEachResourceStart.md)
-* [csvPipeline.md](csvPipeline.md)
-* [parseJsonToResource.md](parseJsonToResource.md)
+* For Each Resource Start
+* CSV Pipeline
+* Parse JSON to Resource
 
 ## References
 

--- a/parseJsonToResource.md
+++ b/parseJsonToResource.md
@@ -37,9 +37,9 @@ If parsing succeeds, the job creates a JsonResource in the workflow context.
 
 ## Related jobs
 
-* [parseCsvToResource.md](parseCsvToResource.md)
-* [parseXmlToResource.md](parseXmlToResource.md)
-* [jsonPipeline.md](jsonPipeline.md)
+* Parse CSV to Resource
+* Parse XML to Resource
+* JSON Pipeline
 
 ## References
 

--- a/placeHolder.md
+++ b/placeHolder.md
@@ -22,9 +22,9 @@ The job does not read or write workflow data.
 
 ## Related jobs
 
-* [setDebugMode.md](setDebugMode.md)
-* [sendHttpRequest.md](sendHttpRequest.md)
-* [routeFromMetaData.md](routeFromMetaData.md)
+* Set Debug Mode
+* Send HTTP Request
+* Route From Meta Data
 
 ## References
 

--- a/resetSynchronizedCounter.md
+++ b/resetSynchronizedCounter.md
@@ -43,9 +43,9 @@ This makes the job useful for resetting counters at the start of a new period, a
 
 ## Related jobs
 
-* [synchronizedCounter.md](synchronizedCounter.md)
-* [findCounters.md](findCounters.md)
-* [routeFromMetaData.md](routeFromMetaData.md)
+* Synchronized Counter
+* Find Counters
+* Route From Meta Data
 
 ## References
 

--- a/routeFromMetaData.md
+++ b/routeFromMetaData.md
@@ -54,9 +54,9 @@ Several routes can match during the same execution.
 
 ## Related jobs
 
-* [executeWorkflow.md](executeWorkflow.md)
-* [filterWorkflowContext.md](filterWorkflowContext.md)
-* [metaDataComparison.md](metaDataComparison.md)
+* Execute Workflow
+* Filter Workflow Context
+* Comparing MetaData
 
 ## References
 

--- a/saveToGroup.md
+++ b/saveToGroup.md
@@ -49,9 +49,9 @@ If dynamic-group tags are provided while creating a new group, the created group
 
 ## Related jobs
 
-* [groupOperations.md](groupOperations.md)
-* [unitOperations.md](unitOperations.md)
-* [findGroups.md](findGroups.md)
+* Group Operations
+* Unit Operations
+* Find Groups
 
 ## References
 

--- a/sendMessageToGroups.md
+++ b/sendMessageToGroups.md
@@ -12,6 +12,7 @@ The properties for configuring the send are described below.
 	* Explicit groups to receive the message.
 * **Send only to active units** (optional; default: false)
 	* If enabled, only active units in the target groups are used as recipients.
+    * Legacy behaviour and is not commonly used.
 * **Use workflow context units** (optional; default: false)
 	* Include units already present in the workflow context.
 * **Override message text** (optional)
@@ -38,7 +39,7 @@ The job can gather recipients from several places.
 
 * Use explicitly connected groups when the audience is known in advance.
 * If no groups are connected, the job can default to workflow-context groups and the temporary group.
-* Enable **Use workflow context units** when units already loaded into workflow context should also be considered.
+* Enable **Use workflow context units** when units already loaded into workflow context, in the temporary group for example, should also be considered.
 
 For app messages, the job also applies default app-message settings such as sender and inbox values from merged settings when needed.
 
@@ -50,9 +51,9 @@ For app messages, the job also applies default app-message settings such as send
 
 ## Related jobs
 
-* [messageTemplate.md](messageTemplate.md)
-* [sendMessageToUnits.md](sendMessageToUnits.md)
-* [findMessageTemplateAsResource.md](findMessageTemplateAsResource.md)
+* Message templates
+* Send Message To Units
+* Find Message Template As Resource
 
 ## References
 

--- a/setDebugMode.md
+++ b/setDebugMode.md
@@ -26,8 +26,8 @@ This job affects the currently running workflow execution only.
 
 ## Related jobs
 
-* [placeHolder.md](placeHolder.md)
-* [executeWorkflow.md](executeWorkflow.md)
+* Place holder
+* Execute Workflow
 
 ## References
 

--- a/synchronizedCounter.md
+++ b/synchronizedCounter.md
@@ -62,9 +62,9 @@ The job counts upward only.
 
 ## Related jobs
 
-* [resetSynchronizedCounter.md](resetSynchronizedCounter.md)
-* [findCounters.md](findCounters.md)
-* [routeFromMetaData.md](routeFromMetaData.md)
+* Reset Synchronized Counter
+* Find Counters
+* Route From Meta Data
 
 ## References
 

--- a/unitOperations.md
+++ b/unitOperations.md
@@ -78,9 +78,9 @@ Typical outcomes include saving to the account, saving to a workflow resource, s
 
 ## Related jobs
 
-* [unitPipeline.md](unitPipeline.md)
-* [findOrCreateUnits.md](findOrCreateUnits.md)
-* [saveToGroup.md](saveToGroup.md)
+* Unit Pipeline
+* Find Or Create Units
+* Save To Group
 
 ## References
 


### PR DESCRIPTION
Update numerous documentation files to use human-readable, capitalized titles in the 'Related jobs' sections instead of raw markdown filenames. Also include minor copy edits and phrasing tweaks (notably in sendMessageToGroups.md where a legacy-behaviour note and a clarified sentence were added). These changes improve readability of cross-references in the docs.