### PR TITLE
Add best-practice tips to job docs

### DIFF
--- a/JOBS_UPDATED.md
+++ b/JOBS_UPDATED.md
@@ -6,34 +6,35 @@ This file tracks all job documentation updates and changes.
 
 | Job Name | Date Updated |
 |----------|--------------|
-| executeWorkflow.md | 2026-03-24 |
-| routeFromMetaData.md | 2026-03-24 |
-| clearWorkflowContext.md | 2026-03-24 |
-| synchronizedCounter.md | 2026-03-24 |
-| resetSynchronizedCounter.md | 2026-03-24 |
-| findUnitsById.md | 2026-03-24 |
-| extractData.md | 2026-03-24 |
-| createJwtSigning.md | 2026-03-24 |
-| forEachResourceStart.md | 2026-03-24 |
-| forEachResourceStop.md | 2026-03-24 |
-| parseJsonToResource.md | 2026-03-24 |
-| parseCsvToResource.md | 2026-03-24 |
-| unitOperations.md | 2026-03-24 |
-| groupOperations.md | 2026-03-24 |
-| findOrCreateUnits.md | 2026-03-24 |
-| saveToGroup.md | 2026-03-24 |
-| findMessageTemplateAsResource.md | 2026-03-24 |
+| addWorkflowStartsTag.md | 2026-03-25 |
+| clearWorkflowContext.md | 2026-03-25 |
+| createJwtSigning.md | 2026-03-25 |
+| dataOperations.md | 2026-03-25 |
+| forEachResourceStart.md | 2026-03-25 |
+| forEachResourceStop.md | 2026-03-25 |
+| incomingHttpTrigger.md | 2026-03-25 |
+| jsonPipeline.md | 2026-03-25 |
+| parseJsonToResource.md | 2026-03-25 |
+| routeFromMetaData.md | 2026-03-25 |
+| sendApiResponse.md | 2026-03-25 |
+| sendHttpRequest.md | 2026-03-25 |
+| unitPipeline.md | 2026-03-25 |
 | answerSender.md | 2026-03-24 |
+| executeWorkflow.md | 2026-03-24 |
+| extractData.md | 2026-03-24 |
+| findMessageTemplateAsResource.md | 2026-03-24 |
+| findOrCreateUnits.md | 2026-03-24 |
+| findUnitsById.md | 2026-03-24 |
+| groupOperations.md | 2026-03-24 |
 | notifyUi.md | 2026-03-24 |
-| sendMessageToGroups.md | 2026-03-24 |
+| parseCsvToResource.md | 2026-03-24 |
 | placeHolder.md | 2026-03-24 |
+| resetSynchronizedCounter.md | 2026-03-24 |
+| saveToGroup.md | 2026-03-24 |
+| sendMessageToGroups.md | 2026-03-24 |
 | setDebugMode.md | 2026-03-24 |
-| addWorkflowStartsTag.md | 2026-03-24 |
-| dataOperations.md | 2026-03-23 |
-| jsonPipeline.md | 2026-03-23 |
-| unitPipeline.md | 2026-03-23 |
-| sendApiResponse.md | 2026-03-17 |
-| sendHttpRequest.md | 2026-03-17 |
+| synchronizedCounter.md | 2026-03-24 |
+| unitOperations.md | 2026-03-24 |
 
 ## Planned Updates
 

--- a/addWorkflowStartsTag.md
+++ b/addWorkflowStartsTag.md
@@ -30,6 +30,8 @@ This job updates the current workflow-start record rather than a unit, group, or
 * Keep tags short, descriptive, and consistent so they remain useful for searching.
 * Prefer stable business identifiers such as order IDs, customer IDs, or correlation IDs over free-form text.
 * Use prefixes such as `order:` or `integration:` when you want tags from different use cases to stay easy to distinguish.
+* Add tags at clear lifecycle points, such as when an integration starts, when a downstream call is made, or when a workflow is routed into a special branch.
+* Avoid using large or highly variable text as tags. Searchability improves when tags stay predictable across executions.
 
 ## Related jobs
 

--- a/addWorkflowStartsTag.md
+++ b/addWorkflowStartsTag.md
@@ -33,6 +33,30 @@ This job updates the current workflow-start record rather than a unit, group, or
 * Add tags at clear lifecycle points, such as when an integration starts, when a downstream call is made, or when a workflow is routed into a special branch.
 * Avoid using large or highly variable text as tags. Searchability improves when tags stay predictable across executions.
 
+## Common tagging patterns
+
+### Retry and failure observability
+
+Use tags to mark bounded-retry outcomes without exposing sensitive data.
+
+Examples:
+
+* `retry:attempt_1`
+* `retry:max_retries_reached`
+* `integration:rate_limited`
+
+Pair this with `dataOperations` retry counters and `routeFromMetaData` retry gates for reliable troubleshooting.
+
+### Callback/event status tags
+
+For callback flows, add a normalized status tag from validated metadata.
+
+Example source:
+
+* `status:{{metadata.event_status}}`
+
+This creates a searchable execution trail for event-driven workflows.
+
 ## Related jobs
 
 * Execute Workflow

--- a/answerSender.md
+++ b/answerSender.md
@@ -35,6 +35,8 @@ The job also aborts if the sender unit cannot be resolved.
 * Use a connected message template when the reply content is static or centrally managed.
 * Use **Message resource** when the workflow selects or builds the message dynamically.
 * Override the sender source only when the workflow intentionally answers a different resolved unit than the default sender.
+* Keep the reply target deterministic. If the workflow can switch between the default sender and an overridden source, make that choice explicit earlier in the flow so replies are easy to audit.
+* Prefer answering with the minimum context needed for the conversation step instead of reusing a broad message template intended for larger group sends.
 
 ## Related jobs
 

--- a/apiCompositionPatterns.md
+++ b/apiCompositionPatterns.md
@@ -1,0 +1,91 @@
+# API Composition Patterns
+
+This guide describes reusable, customer-agnostic workflow composition patterns for building HTTP APIs with jobs and triggers.
+
+## Pattern 1: Request Parse -> Validate -> Process -> Respond
+
+Use this as the default API composition.
+
+1. `incomingHttpTrigger`
+2. `parseJsonToResource`
+3. `routeFromMetaData` (validate required values)
+4. Business jobs (`unitPipeline`, `dataOperations`, `jsonPipeline`)
+5. `sendApiResponse`
+
+Best practice:
+
+* Keep validation branches explicit.
+* Return consistent status codes for the same error class.
+* Build response payloads in `jsonPipeline` instead of returning internal resources directly.
+
+## Pattern 2: Callback Endpoint Acknowledgement
+
+Use for event callbacks where the caller only expects acknowledgement.
+
+1. `incomingHttpTrigger` (public callback path)
+2. `routeFromMetaData` whitelist checks for query/status values
+3. Optional logging/tagging
+4. `sendApiResponse` with `204` and empty body
+
+Best practice:
+
+* Acknowledge quickly, do heavy work asynchronously.
+* Treat all public callback input as untrusted until validated.
+
+## Pattern 3: External API Request with Bounded Retry
+
+Use when external requests can fail transiently.
+
+1. `sendHttpRequest`
+2. Unsuccessful branch -> `routeFromMetaData` on status code
+3. `dataOperations` retry counter increment
+4. Retry gate in `routeFromMetaData`
+5. Retry path or terminal fallback path
+
+Best practice:
+
+* Keep retries bounded.
+* Tag terminal failures with non-sensitive labels.
+* Avoid endless loops.
+
+## Pattern 4: Loop-Driven Processing with Checkpointing
+
+Use for incremental processing of collections or event history.
+
+1. Find/load resource in `unitPipeline`
+2. `forEachResourceStart`
+3. Validate current item (`routeFromMetaData`)
+4. Process only newer/eligible items
+5. Update checkpoint metadata
+6. Persist updates (`saveToAccount`) and exit loop (`forEachResourceStop`)
+
+Best practice:
+
+* Validate each item before expensive calls.
+* Store checkpoints only after successful processing.
+
+## Pattern 5: HTML Response Endpoints
+
+Use when workflow endpoints deliver pages instead of JSON payloads.
+
+1. `incomingHttpTrigger`
+2. Optional metadata extraction (`dataOperations`)
+3. `sendApiResponse` with `text/html`
+
+Best practice:
+
+* Sanitize all dynamic values inserted into HTML.
+* Avoid exposing secrets or auth tokens in rendered URLs.
+* Use `302` only when redirect semantics are intentional.
+
+## Related Docs
+
+* `incomingHttpTrigger.md`
+* `parseJsonToResource.md`
+* `routeFromMetaData.md`
+* `sendHttpRequest.md`
+* `sendApiResponse.md`
+* `forEachResourceStart.md`
+* `forEachResourceStop.md`
+* `jsonPipeline.md`
+* `dataOperations.md`

--- a/clearWorkflowContext.md
+++ b/clearWorkflowContext.md
@@ -47,6 +47,28 @@ Each option affects a different part of the workflow context.
 * Clean up after a branch or subprocess has finished, not before. Downstream jobs often depend on incoming units, groups, or response resources remaining available until the end of that path.
 * When a workflow later depends on `IncomingUnit`, groups, or files, clear those values only after the dependent jobs have finished.
 
+## Common cleanup patterns
+
+### Remove only temporary resources
+
+If temporary resources follow a naming convention, clear them by prefix:
+
+* **Clear resources**: `^tmp_`
+
+### Clear specific resources after an iteration
+
+To remove only known intermediate resources, match exact names:
+
+* **Clear resources**: `^call_log_response$|^call_log_json$`
+
+### Targeted metadata cleanup
+
+To remove one metadata key only:
+
+* **Clear meta data**: `^retry_count$`
+
+Targeted cleanup keeps required context intact while preventing stale temporary values from leaking into later branches.
+
 ## Related jobs
 
 * Filter Workflow Context

--- a/clearWorkflowContext.md
+++ b/clearWorkflowContext.md
@@ -43,6 +43,8 @@ Each option affects a different part of the workflow context.
 
 * Clear only the parts of the workflow context you no longer need.
 * Prefer targeted regex patterns over `.*` unless a full reset is intentional.
+* Adopt temporary naming conventions such as `tmp_` or another clear prefix so cleanup patterns stay precise and safe.
+* Clean up after a branch or subprocess has finished, not before. Downstream jobs often depend on incoming units, groups, or response resources remaining available until the end of that path.
 * When a workflow later depends on `IncomingUnit`, groups, or files, clear those values only after the dependent jobs have finished.
 
 ## Related jobs

--- a/createJwtSigning.md
+++ b/createJwtSigning.md
@@ -38,6 +38,23 @@ The job signs the provided payload and writes the resulting token to the chosen 
 * Use destination names that make the token lifecycle obvious, especially when the JWT is short-lived and immediately consumed by a later HTTP request.
 * Use a clear destination name so later HTTP or API jobs can reference the signed token without ambiguity.
 
+## Common JWT flow
+
+A common pattern is:
+
+1. Prepare numeric time claims (`iat`, `exp`) with `dataOperations`.
+2. Build the claims object with `jsonPipeline`.
+3. Sign claims in this job.
+4. Use the signed token in `sendHttpRequest` authorization headers.
+
+This keeps token generation deterministic and easy to audit.
+
+## Security notes
+
+* Do not write private keys or signed tokens to logs.
+* Avoid passing signed tokens in query strings when header-based authentication is available.
+* Keep JWT lifetime short and regenerate when needed instead of reusing stale tokens across unrelated flows.
+
 ## Related jobs
 
 * Send HTTP Request

--- a/createJwtSigning.md
+++ b/createJwtSigning.md
@@ -32,7 +32,10 @@ The job signs the provided payload and writes the resulting token to the chosen 
 ## Best practices and tips
 
 * Build and validate the payload before signing so the resulting token contains only the claims you intend to send.
+* Keep the payload focused on the minimum claims the target system actually requires. Smaller claim sets are easier to review and reduce unnecessary data sharing.
 * Store private keys securely and inject them from controlled workflow sources rather than hardcoding them broadly in multiple jobs.
+* Prefer keeping the private key in account-level secret storage or an equally controlled source, and reference it from the workflow only when the token is being built.
+* Use destination names that make the token lifecycle obvious, especially when the JWT is short-lived and immediately consumed by a later HTTP request.
 * Use a clear destination name so later HTTP or API jobs can reference the signed token without ambiguity.
 
 ## Related jobs

--- a/dataOperations.md
+++ b/dataOperations.md
@@ -21,6 +21,13 @@ An easy way to remember this could be "brackets replace the string".
 * **Jobs** (optional)
   * Jobs to execute after this job completes.
 
+## Best practices and tips
+
+* Keep operation lists focused on one transformation goal at a time so intermediate values and destinations remain easy to follow.
+* Prefer extracting or filtering input values before running many transformations on them. Smaller, cleaner inputs reduce brittle expressions and unnecessary work.
+* Use clear destination names for intermediate values when later jobs depend on them, especially in longer workflows.
+* When the transformation target is structured JSON rather than individual values, compare this job with [jsonPipeline.md](jsonPipeline.md) before building a long sequence of string operations.
+
 ## Operations
 
 Operations are executed in the sequence defined by the **Order** property within each operation. The **Order** property is available on every operation and is optional — operations without an explicit order value are executed in the order they are listed.

--- a/dataOperations.md
+++ b/dataOperations.md
@@ -28,6 +28,37 @@ An easy way to remember this could be "brackets replace the string".
 * Use clear destination names for intermediate values when later jobs depend on them, especially in longer workflows.
 * When the transformation target is structured JSON rather than individual values, compare this job with [jsonPipeline.md](jsonPipeline.md) before building a long sequence of string operations.
 
+## Common transformation patterns
+
+### Extract with regex before routing
+
+Use **Extract value regex** to normalize values before `routeFromMetaData`.
+
+Examples:
+
+* Extract first subdomain from host: pattern `^[^.]+`
+* Validate digits-only value: pattern `^\\d+$`
+* Extract UUID from a path: pattern `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
+
+### Retry counter increment
+
+Use **Calculate data** to increment counters safely.
+
+* **Source**: `{{metadata.retries}}+1`
+* **Destination**: `metadata.retries`
+
+Then gate retries in `routeFromMetaData` with a max-retry comparison.
+
+### Prepare timestamp claims for JWT payloads
+
+Use date/time and arithmetic operations to prepare `iat`/`exp` values before `createJwtSigning`.
+
+Pattern:
+
+1. Calculate current epoch value into metadata.
+2. Add token lifetime offset (for example in seconds) for expiration.
+3. Build final JSON claims in `jsonPipeline` and sign in `createJwtSigning`.
+
 ## Operations
 
 Operations are executed in the sequence defined by the **Order** property within each operation. The **Order** property is available on every operation and is optional — operations without an explicit order value are executed in the order they are listed.

--- a/executeWorkflow.md
+++ b/executeWorkflow.md
@@ -45,6 +45,8 @@ The job searches for the target workflow, starts it, and then continues based on
 * Prefer workflow IDs when the target workflow name may change over time.
 * Pass only the metadata the called workflow actually needs so the interface between workflows stays clear.
 * Use **Ignore current workflow metadata** together with **Execute with metadata** when you want the called workflow to behave like a clean subprocess.
+* Treat the called workflow like an explicit contract: define which metadata keys, triggers, and forwarded resources it should receive instead of relying on broad inherited context.
+* Exclude temporary or large resources with **Exclude resources regex** when the child workflow does not need them. This keeps executions lighter and reduces accidental coupling between workflows.
 * Be careful with **Allow recursive executions**. Add a clear stop condition elsewhere in the workflow design to avoid runaway loops.
 
 ## Related jobs

--- a/extractData.md
+++ b/extractData.md
@@ -48,6 +48,7 @@ The job performs exactly one extraction mode per execution.
 
 * Choose the extraction mode based on where downstream jobs expect to find the data: workflow groups, temporary group, metadata, or a resource.
 * Keep process-trigger-dependent modes near the relevant trigger flow so the required event data is still available and easy to understand.
+* Extract only the structures the next jobs actually need. Moving everything into workflow context makes later routing and cleanup harder to reason about.
 
 ## Related jobs
 

--- a/findMessageTemplateAsResource.md
+++ b/findMessageTemplateAsResource.md
@@ -39,6 +39,8 @@ The job finds matching templates and stores them in the named workflow resource.
 * Give the result resource a descriptive name so later message jobs are easier to read.
 * Use metadata filters when template selection should be stable even if names change.
 * Keep pagination explicit if the workflow may return more than one matching template.
+* Use metadata that reflects stable business dimensions such as language, message type, or channel rather than display names that are more likely to drift over time.
+* Narrow the search as much as possible before downstream send steps so the workflow resolves one intended template instead of passing along an ambiguous result set.
 
 ## Related jobs
 

--- a/findOrCreateUnits.md
+++ b/findOrCreateUnits.md
@@ -43,6 +43,7 @@ The distinct options are useful when duplicate phone numbers or email addresses 
 ## Best practices and tips
 
 * Enable creation only when the workflow is allowed to provision new units automatically.
+* Use the smallest reliable search source you have, such as one confirmed email address or phone number, instead of broad mixed identifiers that can create ambiguous matches.
 * Use the distinct options when duplicate channel data exists and downstream jobs expect a smaller result set.
 * Set `IncomingUnit` only when a single-unit outcome is the intended behavior for later jobs.
 * If the workflow needs more than a simple find-or-create pattern, consider using [unitPipeline.md](unitPipeline.md) instead. It is often the better fit for newer workflows that combine search, creation, filtering, updates, and saving in one sequence.

--- a/forEachResourceStart.md
+++ b/forEachResourceStart.md
@@ -37,6 +37,8 @@ When the loop reaches [forEachResourceStop.md](forEachResourceStop.md), executio
 * Choose a clear **Current item name** so expressions inside the loop remain readable.
 * Keep the loop body focused on work that belongs to one item at a time.
 * Use **Nested for each name** only when you need nested loops, and make sure the start and stop jobs use the same value.
+* Filter or reduce the resource before entering the loop when possible. Smaller iteration sets are easier to debug and reduce unnecessary downstream calls.
+* Keep external API calls or account writes inside the loop deliberate, especially for large resources. When needed, combine looping with batching or quota control elsewhere in the workflow.
 
 ## Related jobs
 

--- a/forEachResourceStart.md
+++ b/forEachResourceStart.md
@@ -40,6 +40,31 @@ When the loop reaches [forEachResourceStop.md](forEachResourceStop.md), executio
 * Filter or reduce the resource before entering the loop when possible. Smaller iteration sets are easier to debug and reduce unnecessary downstream calls.
 * Keep external API calls or account writes inside the loop deliberate, especially for large resources. When needed, combine looping with batching or quota control elsewhere in the workflow.
 
+## Common loop patterns
+
+### Validate each item before expensive work
+
+When each item may be incomplete, validate first and only continue on valid items.
+
+Example pattern:
+
+1. Extract a required value from the current item (for example phone, ID, or status).
+2. Route on missing or invalid values.
+3. Continue with API calls only on the valid branch.
+
+This keeps loop processing efficient and reduces avoidable external failures.
+
+### Nested loops
+
+When iterating within an iteration, set **Nested for each name** on both start and stop jobs for each level.
+
+Example naming:
+
+* Outer loop: `user_loop`
+* Inner loop: `item_loop`
+
+Clear naming helps avoid mismatched stop jobs and makes execution order easier to follow.
+
 ## Related jobs
 
 * For Each Resource Stop

--- a/forEachResourceStop.md
+++ b/forEachResourceStop.md
@@ -22,6 +22,7 @@ This job does not process data by itself. Instead, it controls how the loop cont
 * Always pair this job with [forEachResourceStart.md](forEachResourceStart.md); the loop will not work correctly without a matching start job.
 * Use **Nested for each name** only when you actually need nested loops. Leave it empty for simpler workflows.
 * Keep the jobs inside the loop focused on the current item so the loop is easy to reason about and debug.
+* Keep nested loops rare and clearly named. The more loop levels a workflow has, the harder it becomes to understand execution order and failure behavior.
 
 ## Related jobs
 

--- a/forEachResourceStop.md
+++ b/forEachResourceStop.md
@@ -23,6 +23,8 @@ This job does not process data by itself. Instead, it controls how the loop cont
 * Use **Nested for each name** only when you actually need nested loops. Leave it empty for simpler workflows.
 * Keep the jobs inside the loop focused on the current item so the loop is easy to reason about and debug.
 * Keep nested loops rare and clearly named. The more loop levels a workflow has, the harder it becomes to understand execution order and failure behavior.
+* In nested scenarios, verify each stop job points to the intended loop level so completion paths run in the correct order.
+* Use the `When completed` path from the start job for summary work (for example final logging or cleanup), not item-level processing.
 
 ## Related jobs
 

--- a/groupOperations.md
+++ b/groupOperations.md
@@ -41,6 +41,7 @@ The pipeline follows a consistent sequence.
 * Use filters before member operations when only a subset of groups should be changed.
 * Save to a resource when later jobs need the resulting groups without immediately persisting changes to the account.
 * Keep group-metadata updates focused on a small number of keys so the pipeline remains easy to review.
+* When later jobs only need a subset of groups, filter early and keep the working set small before adding or removing members.
 
 ## Related jobs
 

--- a/incomingHttpTrigger.md
+++ b/incomingHttpTrigger.md
@@ -1,14 +1,14 @@
-# Incoming http trigger #
+# Incoming HTTP Trigger
 
 
-_Will start the workflow if a request to the http-in-api matches the criteria_
+_Starts the workflow when an HTTP-in API request matches the trigger criteria._
 
 ## Properties
 
-* **Method** - Choose the http method the trigger will match on, choose * if it should match on any method
-* **Token** - Enter a token that should be used when executing the trigger. Any token can be used, but preferrable a REST API-token/Authentication token because they have a longer lifetime. These are found and created under "Administrator Tools"->REST-Api tokens (format: 00000000-0000-0000-0000-000000000000). The token can be left empty if you want to use different tokens. ***Optional***
-* **Path** - By setting this value your request must have a matching path. This should preferrable be used in combination with the subdomain option. ***Optional***
-* **Sub domain** - This option enables you to use a subdomain infront of the normal in.bosbec.io domain. ***Optional, but recommended***
+* **Method** - Choose the HTTP method the trigger will match on. Choose `*` if it should match any method.
+* **Token** - Enter a token to execute the trigger. Any token can be used, but preferably a REST API token/authentication token because it has a longer lifetime. Tokens are found and created under `Administrator Tools -> REST API tokens` (format: `00000000-0000-0000-0000-000000000000`). The token can be left empty if you want to support different tokens. ***Optional***
+* **Path** - By setting this value, your request must have a matching path. This is preferably used in combination with the subdomain option. ***Optional***
+* **Sub domain** - Enables use of a subdomain in front of the normal `in.bosbec.io` domain. ***Optional, but recommended***
 * **Is public** - By setting this to "true" the trigger can be triggered without any provided token. It can be a good option when a resource needs to be shared and it is not possible or required to require authentication. Keep in mind that the resource will be available to anyone with the correct path. ***Optional***
 * **Incoming http request resource name** - The name where the request resource will be stored when running the workflow.
 * **Incoming unit resource name** - The resource name for the related unit when running the workflow.
@@ -25,9 +25,11 @@ This job can be connected to the following workflow elements.
 
 ## Usage
 
-This trigger reacts to HTTPS-requests to the *.in.bosbec.io api. Depending on the channels that are open for your account, the trigger may react to everything from such a channel or when the given criteria is met.
+Incoming HTTP traffic first enters an HTTP channel and is then filtered by triggers. A common setup is to keep the channel relatively open for one external system and use trigger settings (method/path) to route requests to the correct workflow.
 
-The request must use a http verb matching what's configured for the trigger (GET, POST, DELETE...).
+This trigger reacts to HTTPS requests that match both the channel and trigger criteria.
+
+The request must use an HTTP verb matching what is configured for the trigger (`GET`, `POST`, `DELETE`, ...).
 
 When token is provided you can call either:
 
@@ -37,7 +39,7 @@ When token is provided you can call either:
 When a path is provided you can call either:
 
 * https://in.bosbec.io/2/[TOKEN]/[PATH] where [TOKEN] is any valid token, or the provided token.
-* https://in.bosbec.io/2/[PATH] and any vald token as the header `api-key` or `Authorization` (preferred way).
+* https://in.bosbec.io/2/[PATH] and any valid token as the header `api-key` or `Authorization` (preferred way).
 
 When a sub domain is provided you can call:
 
@@ -55,54 +57,87 @@ When is public is set to `true`:
 
 When trying to access data from the incoming request, assuming that the request-resource has name `request1`:
 
-* `request1.header.content-type` would get the value in the content-type header.
-* `request1.body` gets the body
-* `request1.headers` gets all headers comma-separated
-* `request1.path` gets the path 
-* `request1.full_path` gets the full path
-* `request1.method` gets the method eg. post/get
-* `request1.querykeys` gets the keys in the query as comma-separated
-* `request1.query.x` gets the value for the query-parameter 'x'
-* `request1.contenttype` a shortcut to get the contet-type header
-* `request1.ip` gets the requester-ip
+* `{{request1.header.content-type}}` would get the value in the content-type header.
+* `{{request1.body}}` gets the body
+* `{{request1.headers}}` gets all headers comma-separated
+* `{{request1.path}}` gets the path 
+* `{{request1.full_path}}` gets the full path
+* `{{request1.method}}` gets the method, for example post/get
+* `{{request1.querykeys}}` gets the keys in the query as comma-separated
+* `{{request1.query.x}}` gets the value for the query-parameter 'x'
+* `{{request1.contenttype}}` a shortcut to get the content-type header
+* `{{request1.ip}}` gets the requester-ip
+
+## Channels and trigger alignment
+
+The incoming channel and trigger can share overlapping properties, especially method and path.
+
+Recommended approach:
+
+1. Configure the HTTP channel as the broad entry point for a source system.
+2. Use one or more triggers to filter by method/path and start specific workflows.
+
+For HTTP channels, the channel-level matching properties are:
+
+* Method
+* Subdomain
+* Domain
+* Path
+
+Channel fields left empty are treated as wildcards and are not required to match.
 
 
 ## Authentication tokens
-The authentication tokens used must have permissions to run the trigger or workflow. When resticting the permissions it's possible to set that only a specific trigger or workflow can be started.
 
-One or multiple values can be defined in each Allow definition.
+Authentication tokens must have permission to run the trigger or workflow. When restricting permissions, you can allow only a specific trigger or workflow.
 
-To define a trigger use the following resource configuration:
-```
-{
-    "Resource": "triggers",
-    "Allow": [
-        "sometrigger",
-        "bf3c798a-76ce-4e20-b4c0-5ccb43dc5f07"
-    ],
-    "Deny": []
-}
-```
-sometrigger is the trigger name
-bf3c798a-76ce-4e20-b4c0-5ccb43dc5f07 represents a trigger id that can be triggered
+Webhook authentication usually follows one of these modes:
 
-
-To define a workflow use the following resource configuration:
-```
-{
-    "Resource": "workflows",
-    "Allow": [
-        "someworkflow",
-        "20edb780-a43c-4671-9182-9990bfa7169d"
-    ],
-    "Deny": []
-}
-```
-someworkflow is the wokflow name
-20edb780-a43c-4671-9182-9990bfa7169d represents a trigger id that can be triggered
+1. Public trigger (no authentication required).
+2. Trigger requires a valid token.
+3. Trigger requires a specific token.
 
 ## Other
 
-If it's possible use the api-token header instead of adding your token to the request path.
-If you run into problems where the workflow execution stops before you get a response, as an example this can happen when you make a Remote-Http-Request before the response to the api-endpoint. You can add the header *processing-until-response : true* to the request, and the request will not stop processing until a response has been created (or some time out).
-You can also set a custom timeout with the header *processing-time-out : 1000* where the value is milliseconds to wait.
+If possible, use the API token header instead of adding the token to the request path.
+If workflow execution stops before a response is returned, for example after a Remote HTTP Request before API response creation, add the header `processing-until-response: true`. This keeps processing active until a response is created (or timeout is reached).
+You can also set a custom timeout with `processing-time-out: 1000`, where the value is milliseconds to wait.
+
+## Testing incoming webhooks
+
+When testing webhook setup, start with a simple trigger/workflow path that returns `200` on successful receipt. After connectivity is verified, add routing, validation, and business logic branches.
+
+## Best practices
+
+* Prefer explicit HTTP methods over `*` unless a single endpoint truly must accept multiple verbs.
+* For public endpoints (`Is public = true`), validate input early using `dataOperations` and `routeFromMetaData` before any account updates or external requests.
+* Prefer tokens in request headers (`api-key` or `Authorization`) over query strings to reduce leakage through logs and browser history.
+* Keep trigger paths stable and descriptive so downstream routing and monitoring stay predictable.
+* When building callback endpoints, return a quick response (often `204`) and move heavy processing to asynchronous workflow paths.
+
+## Common trigger patterns
+
+### Public callback endpoint with whitelist validation
+
+Use this pattern for event callbacks where the source system calls your endpoint and only expects acknowledgement.
+
+1. Configure trigger with explicit method and path.
+2. Validate critical query values in `routeFromMetaData` using strict regex (whitelist).
+3. Route invalid values to a safe fallback branch.
+4. Return `204` quickly using `sendApiResponse`.
+
+This keeps callback endpoints deterministic and reduces accidental processing of malformed input.
+
+### Header-first authentication
+
+When the endpoint is not public, prefer header-based auth over path/query token patterns.
+
+* Use `Authorization` or `api-key` headers.
+* Keep tokens out of URL paths and query strings.
+* Restrict token permissions to only the required trigger or workflow.
+
+## Security notes
+
+* For `Is public = true` triggers, treat all incoming values as untrusted until validated.
+* Avoid exposing sensitive values in error responses from public paths.
+* If wildcard method (`*`) is enabled, route on `{{request_resource.method}}` early so only expected verbs continue.

--- a/jsonPipeline.md
+++ b/jsonPipeline.md
@@ -191,6 +191,17 @@ Example patterns:
 * Use **Parse JSON** when you receive raw JSON text from metadata or external responses.
 * Save transformed output to a clearly named resource when later jobs, such as HTTP requests or iteration steps, depend on the result.
 
+## Common API composition pattern
+
+Use JSON Pipeline to build a stable response contract before `sendApiResponse`.
+
+Example flow:
+
+1. `Load resource` from a search result or upstream response.
+2. `Transform` into a strict response object (only required keys).
+3. `Save as resource` to a dedicated resource (for example `api_response`).
+4. Return `{{api_response}}` from `sendApiResponse` with `application/json`.
+
 ## Related jobs
 
 * Data Operations

--- a/jsonPipeline.md
+++ b/jsonPipeline.md
@@ -186,8 +186,10 @@ Example patterns:
 
 * Start with **Load resource** or **Transform** and end with **Save as resource** for predictable pipelines.
 * Keep transformations small and explicit; multiple simple steps are usually easier to maintain than one large transformation.
+* Filter array data as early as possible so later transformation steps only handle the items that should continue through the workflow.
 * Use `{{this.key}}` for current JSON values and `{{metadata.key}}` for workflow values.
 * Use **Parse JSON** when you receive raw JSON text from metadata or external responses.
+* Save transformed output to a clearly named resource when later jobs, such as HTTP requests or iteration steps, depend on the result.
 
 ## Related jobs
 

--- a/notifyUi.md
+++ b/notifyUi.md
@@ -33,8 +33,14 @@ The notification appears in the admin UI as a toast.
 * Keep UI notifications short and action-oriented.
 * Use account-wide topics only for information relevant to multiple administrators.
 * Prefer persistent notifications only when the message requires deliberate acknowledgement.
+* Send UI notifications for operational visibility or manual follow-up, not as the only record of an important workflow outcome. Store key results in workflow data or logs when they matter later.
+* Include just enough context in the message for the administrator to understand the event, such as a correlation ID, order ID, or a short status summary.
 
 ## Related jobs
+
+* Add Workflow Starts Tag
+* Set Debug Mode
+* Execute Workflow
 
 ## References
 

--- a/parseCsvToResource.md
+++ b/parseCsvToResource.md
@@ -48,6 +48,7 @@ If parsing succeeds, the job creates a CsvResource that downstream jobs can insp
 * Enable **Parse first row as headers** whenever the incoming CSV includes field names; it makes downstream expressions easier to understand.
 * Use a custom delimiter only when the source data actually requires it.
 * If the input may contain uneven rows, decide explicitly whether padding mismatched rows is safer than failing early.
+* Parse the CSV into a named resource once, then iterate or transform from that resource instead of reparsing the same text in several places.
 
 ## Related jobs
 

--- a/parseJsonToResource.md
+++ b/parseJsonToResource.md
@@ -32,6 +32,7 @@ If parsing succeeds, the job creates a JsonResource in the workflow context.
 ## Best practices and tips
 
 * Give the destination resource a descriptive name so downstream expressions stay readable.
+* When the source can contain malformed or mixed content, validate or isolate the JSON-producing part before parsing so downstream steps do not depend on ambiguous input.
 * Parse once and reuse the resulting JsonResource instead of repeatedly handling the same payload as plain text.
 * When the JSON contains arrays, keep extraction expressions simple and move advanced array filtering into dedicated steps only when needed.
 

--- a/parseJsonToResource.md
+++ b/parseJsonToResource.md
@@ -36,6 +36,27 @@ If parsing succeeds, the job creates a JsonResource in the workflow context.
 * Parse once and reuse the resulting JsonResource instead of repeatedly handling the same payload as plain text.
 * When the JSON contains arrays, keep extraction expressions simple and move advanced array filtering into dedicated steps only when needed.
 
+## Error handling pattern
+
+When JSON input may be invalid, design an explicit failure path.
+
+Suggested pattern:
+
+1. Extract or isolate the expected JSON input source before parsing.
+2. Run this job to parse into a dedicated destination resource.
+3. Route downstream processing based on whether required parsed keys are available.
+4. Return a clear API response (for example `400`) or fallback handling when parsing fails.
+
+This keeps malformed input from propagating into account updates or external API requests.
+
+## Related composition pattern
+
+Common API flow:
+
+* `incomingHttpTrigger` -> `parseJsonToResource` -> validation route (`routeFromMetaData`) -> processing jobs -> `sendApiResponse`
+
+Using this sequence keeps request parsing, validation, and response behavior explicit.
+
 ## Related jobs
 
 * Parse CSV to Resource

--- a/placeHolder.md
+++ b/placeHolder.md
@@ -19,6 +19,8 @@ The job does not read or write workflow data.
 * Use a Place holder job when you want to make workflow branches readable without introducing temporary logic.
 * Keep the job name or description meaningful so it is obvious why the branch exists.
 * Use this job on success or failure paths when you want the destination of a route to stay visible during design and review.
+* Prefer a placeholder over ad hoc temporary logic when a branch exists for structure only. This keeps the workflow explicit without implying processing that does not happen yet.
+* Replace long-lived placeholders with real handling or a clearly named terminal branch once the integration behavior is decided.
 
 ## Related jobs
 

--- a/resetSynchronizedCounter.md
+++ b/resetSynchronizedCounter.md
@@ -39,6 +39,7 @@ This makes the job useful for resetting counters at the start of a new period, a
 
 * Use the same **Counter name** and **Counter key** conventions here as in [synchronizedCounter.md](synchronizedCounter.md) so the intended counter is reset reliably.
 * Reset counters deliberately at clear lifecycle boundaries such as daily quotas, campaign restarts, or successful completion of a guarded process.
+* Reset the counter only after the business event that should reopen capacity has actually happened. Early resets can undermine the protection that the counter was meant to provide.
 * Update **Counter limit** only when the reset should also change the future threshold, not just the current value.
 
 ## Related jobs

--- a/routeFromMetaData.md
+++ b/routeFromMetaData.md
@@ -51,6 +51,7 @@ Several routes can match during the same execution.
 * When the logic can be expressed as a sequence of decisions, prefer chaining multiple [routeFromMetaData.md](routeFromMetaData.md) jobs instead of relying on several matches in a single job. This reduces the risk of race conditions or conflicting workflow-context changes further downstream.
 * Enable **Split workflow context on multiple matches** when several routes may match and the branches should not modify the same workflow context.
 * Prefer **Compare value source** over copying values into static fields when both sides of the comparison are dynamic.
+* Route on stable, well-named metadata keys so branching remains understandable and does not depend on temporary or ambiguous values.
 
 ## Related jobs
 

--- a/routeFromMetaData.md
+++ b/routeFromMetaData.md
@@ -48,10 +48,44 @@ Several routes can match during the same execution.
 
 * Use **Route destination on no match** to make the fallback behavior explicit.
 * Avoid designing routes so that multiple branches match at the same time when possible.
-* When the logic can be expressed as a sequence of decisions, prefer chaining multiple [routeFromMetaData.md](routeFromMetaData.md) jobs instead of relying on several matches in a single job. This reduces the risk of race conditions or conflicting workflow-context changes further downstream.
+* When the logic can be expressed as a sequence of decisions, prefer chaining multiple `routeFromMetaData` jobs instead of relying on several matches in a single job. This reduces the risk of race conditions or conflicting workflow-context changes further downstream.
 * Enable **Split workflow context on multiple matches** when several routes may match and the branches should not modify the same workflow context.
 * Prefer **Compare value source** over copying values into static fields when both sides of the comparison are dynamic.
 * Route on stable, well-named metadata keys so branching remains understandable and does not depend on temporary or ambiguous values.
+
+## Common routing patterns
+
+### Regex whitelist validation
+
+Use `regex` comparisons to allow only known values before continuing.
+
+Example:
+
+* **Meta data source**: `{{request_resource.query.status}}`
+* **Compare operator**: `regex`
+* **Compare value**: `^(started|ringing|answered|completed|rejected)$`
+
+This pattern is useful for public callback endpoints where query values must be validated early.
+
+### Numeric threshold checks
+
+Use numeric comparisons when filtering on counters, durations, or scores.
+
+Examples:
+
+* Route only when `{{metadata.duration}} >= 30`.
+* Route only when `{{metadata.retries}} <= {{metadata.max_retries}}`.
+
+### Retry gate with fallback
+
+Use `Route destination on no match` as the terminal path when retry conditions are no longer met.
+
+Pattern:
+
+* Match route: retry allowed -> increment and retry path.
+* No-match route: max retries reached -> stop, tag, or send final error response.
+
+This makes retry behavior deterministic and prevents endless loops.
 
 ## Related jobs
 

--- a/sendApiResponse.md
+++ b/sendApiResponse.md
@@ -24,6 +24,42 @@ The properties for configuring the response are described below.
 * Keep the response body focused on the fields the caller actually needs. Smaller, explicit responses are easier to consume and reduce accidental data leakage.
 * Use error status codes and response bodies consistently across failure paths so external systems can react predictably when validation or downstream processing fails.
 
+## Common response patterns
+
+These patterns are commonly used in API and callback workflows.
+
+### 200 OK with structured JSON
+
+Use `200` when the request succeeds and you return data.
+
+* Set **Response status code** to `200`.
+* Set **Response content type** to `application/json`.
+* Build the response body from workflow context, for example `{{api_response}}`.
+
+### 204 No Content for callbacks
+
+Use `204` when the caller only needs acknowledgement and no payload.
+
+* Set **Response status code** to `204`.
+* Leave **Response body** empty.
+* Keep the callback path lightweight so acknowledgements are fast.
+
+### 400 and 404 with minimal payload
+
+Use `400` for validation failures and `404` when a requested item is not found.
+
+* Return a predictable error structure, or an intentionally empty body if the external contract expects that.
+* Keep behavior consistent across all failure branches that represent the same error class.
+
+### HTML responses
+
+Some workflows return HTML from this job.
+
+* Set **Response content type** to `text/html`.
+* Use `200` for page delivery and `302` only when redirect semantics are intentional.
+* Sanitize or strictly validate any dynamic value inserted into HTML.
+* Avoid putting sensitive tokens in URLs rendered by HTML responses.
+
 ## Related jobs and triggers
 
 * Incoming HTTP Trigger

--- a/sendApiResponse.md
+++ b/sendApiResponse.md
@@ -21,6 +21,8 @@ The properties for configuring the response are described below.
 * Return a clear status code and body that matches your API contract so integrations are easier to debug.
 * Set Response content type explicitly when returning JSON or plain text to avoid ambiguity for the caller.
 * Include only the headers you need in Response headers to keep responses predictable.
+* Keep the response body focused on the fields the caller actually needs. Smaller, explicit responses are easier to consume and reduce accidental data leakage.
+* Use error status codes and response bodies consistently across failure paths so external systems can react predictably when validation or downstream processing fails.
 
 ## Related jobs and triggers
 

--- a/sendHttpRequest.md
+++ b/sendHttpRequest.md
@@ -61,6 +61,10 @@ When a response is captured to a resource, the following properties are availabl
 
 ## Best practices and tips
 * Name your response resource something descriptive so that the workflow is easier to work with in the future. A more descriptive name makes the workflow more readable.
+* Send the minimum data the receiving system needs. Smaller request bodies are easier to validate, reduce accidental data exposure, and make troubleshooting simpler.
+* Use **Response validation** deliberately. Prefer **Valid response code and response type** when downstream jobs depend on structured JSON or XML, so invalid payloads fail early instead of propagating unexpected data.
+* Route failed or unexpected responses to **Jobs to execute after unsuccessful response** when the workflow must branch on API failures, retries, or fallback handling rather than silently continuing.
+* When calling authenticated APIs, resolve secrets and tokens from controlled workflow sources instead of scattering credentials across multiple jobs or hardcoded values.
 * Building the request body can also be done in a JSON pipeline before running this job, saving the JSON to a JSON resource and referencing the resource using the {{resourceName}} syntax.
 * Are you looking to send a response to an incoming request? Take a look at Send API Response instead.
 

--- a/sendHttpRequest.md
+++ b/sendHttpRequest.md
@@ -60,6 +60,7 @@ When a response is captured to a resource, the following properties are availabl
   * Timestamp (UTC) when the request was sent.
 
 ## Best practices and tips
+
 * Name your response resource something descriptive so that the workflow is easier to work with in the future. A more descriptive name makes the workflow more readable.
 * Send the minimum data the receiving system needs. Smaller request bodies are easier to validate, reduce accidental data exposure, and make troubleshooting simpler.
 * Use **Response validation** deliberately. Prefer **Valid response code and response type** when downstream jobs depend on structured JSON or XML, so invalid payloads fail early instead of propagating unexpected data.
@@ -68,13 +69,52 @@ When a response is captured to a resource, the following properties are availabl
 * Building the request body can also be done in a JSON pipeline before running this job, saving the JSON to a JSON resource and referencing the resource using the {{resourceName}} syntax.
 * Are you looking to send a response to an incoming request? Take a look at Send API Response instead.
 
+## Branching and retry patterns
+
+### Status-aware branching
+
+When a request can fail in different ways, route the unsuccessful path through a `routeFromMetaData` job and branch on `{{responseResource.statuscode}}`.
+
+Example strategy:
+
+* `401` -> refresh token path.
+* `429` -> delayed retry path.
+* Any other non-success -> fallback logging or error response path.
+
+This keeps failure handling explicit and avoids hidden behavior differences.
+
+### Bounded retries
+
+Avoid unbounded retry loops.
+
+* Track retry count in metadata (for example `metadata.retries`).
+* Increment in a `dataOperations` job.
+* Route on max retries before attempting another request.
+* Tag or log max-retry events for observability.
+
+### Timeout handling
+
+Use **Timeout** deliberately based on the target API behavior.
+
+* Short timeouts are useful for callbacks and latency-sensitive paths.
+* Longer timeouts may be needed for heavy external operations.
+* Treat timeout failures as first-class failure branches rather than generic errors.
+
+### Security notes
+
+* Prefer `Authorization` headers over query-string tokens.
+* Avoid logging full request headers when they contain credentials.
+* Keep token generation and signing in dedicated jobs and pass only the final token value into this job.
+
 ## Related jobs
+
 * Send API Response
 * Parse JSON to resource
 * Parse XML to resource
 * JSON Pipeline
 
 ## References
+
 * [Quickstart: Your first API](https://help.bosbec.com/knowledge-base/quickstart-your-first-api/)
   * Step-by-step guide to getting started with HTTP requests
 * [Building your first API](https://help.bosbec.com/knowledge-base/building-your-first-api/)

--- a/sendMessageToGroups.md
+++ b/sendMessageToGroups.md
@@ -46,7 +46,9 @@ For app messages, the job also applies default app-message settings such as send
 ## Best practices and tips
 
 * Connect groups explicitly when the intended audience should be obvious from the workflow design.
+* Keep recipient selection deterministic. If the workflow can pull receivers from explicit groups, workflow-context groups, temporary groups, and workflow-context units, document which source is intended for that flow.
 * Use **Ignore send if no receivers** only when an empty recipient set is expected and should not be treated as an error.
+* Resolve the message from one primary source when possible, either a connected template or a message resource, so the send step is easy to reason about and troubleshoot.
 * Keep message selection clear: use either a connected message template or a message resource when possible, rather than mixing both patterns unnecessarily.
 
 ## Related jobs

--- a/setDebugMode.md
+++ b/setDebugMode.md
@@ -23,6 +23,8 @@ This job affects the currently running workflow execution only.
 * Remove it or disable **Debug mode** after troubleshooting so normal workflow runs do not stop unexpectedly.
 * There is now also an alternative breakpoint mechanism in the workflow builder: click the arrow between two jobs and select `Set breakpoint`.
 * Use the arrow-based breakpoint when you want a lighter-weight breakpoint without adding a dedicated job to the workflow.
+* Keep debug pauses close to the specific transformation, API call, or route decision you are investigating so the captured workflow state stays focused.
+* Avoid leaving active debug stops in workflows that handle time-sensitive integrations or larger iteration sets, since they can interrupt operational processing.
 
 ## Related jobs
 

--- a/synchronizedCounter.md
+++ b/synchronizedCounter.md
@@ -58,6 +58,9 @@ The job counts upward only.
 
 * Keep **Counter name** stable and use **Counter key** for the runtime-specific uniqueness.
 * Always store **Output value** and **Output result** so later jobs can decide what to do.
+* Use this job when the workflow must protect a shared quota or rate limit across parallel executions, not just as a general-purpose counter.
+* Branch explicitly on **Output result** when limits are reached so the workflow can postpone, skip, or notify instead of continuing as if capacity is still available.
+* Keep the key tied to the business boundary you actually want to protect, such as a sender, customer, campaign, or API quota bucket.
 * Pair this job with [resetSynchronizedCounter.md](resetSynchronizedCounter.md) when the counter should be reset between periods or workflows.
 
 ## Related jobs

--- a/unitOperations.md
+++ b/unitOperations.md
@@ -73,6 +73,7 @@ Typical outcomes include saving to the account, saving to a workflow resource, s
 ## Best practices and tips
 
 * Use several small find and filter steps instead of one overloaded search when readability matters.
+* Filter as early as possible after broad find steps so later updates and store operations only touch the units that actually matter.
 * Turn on continue-on-error only when the workflow can safely proceed with partial results.
 * When deduplication or merging is the real goal, compare this job with [unitPipeline.md](unitPipeline.md) before choosing an approach.
 

--- a/unitPipeline.md
+++ b/unitPipeline.md
@@ -295,6 +295,30 @@ Updates unit data for all units in the current resource.
 * Save changes to account to persist the created or changed units.
 * Use paging, take, or targeted find criteria when the account can return large result sets. Smaller batches are easier to debug and reduce the risk of over-processing.
 
+## Common pipeline patterns
+
+### Search, validate, then persist
+
+A robust pattern for API-style workflows:
+
+1. **Find Units** or **Load Resource**.
+2. Validate result count or required metadata in `routeFromMetaData`.
+3. Apply **Update Unit Data** or other mutations.
+4. Save with **Save To Account**.
+5. Return response through `sendApiResponse`.
+
+### Incremental processing checkpoint
+
+When processing ordered records repeatedly, store a checkpoint in unit metadata and update it only after successful handling.
+
+Example pattern:
+
+* Compare incoming item ID/timestamp to stored checkpoint.
+* Process only newer items.
+* Save updated checkpoint in unit metadata.
+
+This reduces duplicate processing between workflow runs.
+
 ## References
 
 * [Unit Pipeline: Merging units](https://help.bosbec.com/knowledge-base/unit-pipeline-merging-units/)

--- a/unitPipeline.md
+++ b/unitPipeline.md
@@ -290,9 +290,10 @@ Updates unit data for all units in the current resource.
 ## Best practices and tips
 
 * Start the pipeline by loading a resource or finding them from the account.
-* Perform the filters, followed by updates.
+* Perform broad find steps first, then filter early before updates or saves so fewer units flow through the expensive parts of the pipeline.
 * Save changes to resource to reference the units later in the process.
 * Save changes to account to persist the created or changed units.
+* Use paging, take, or targeted find criteria when the account can return large result sets. Smaller batches are easier to debug and reduce the risk of over-processing.
 
 ## References
 


### PR DESCRIPTION
Add concise best-practice tips and clarifications across 26 workflow job documentation files. Changes emphasize consistent naming, filtering early/limiting result sets, minimizing shared context and data payloads, secure handling of secrets/JWTs, deliberate API and loop usage (batching/quota control), clearer debug and counter/reset guidance, and improved template/message selection and response handling. These edits aim to improve readability, reduce accidental data exposure/coupling, and make workflows easier to maintain and audit.